### PR TITLE
Mark "ZonedDateTime" with @XmlTransient annotation so JAXB will ignore it when mapping state to XML

### DIFF
--- a/Semaphore-SES-Client/src/main/java/com/smartlogic/ses/client/AbstractSimpleNodeDate.java
+++ b/Semaphore-SES-Client/src/main/java/com/smartlogic/ses/client/AbstractSimpleNodeDate.java
@@ -5,6 +5,8 @@ import java.time.format.DateTimeFormatter;
 
 import org.w3c.dom.Element;
 
+import javax.xml.bind.annotation.XmlTransient;
+
 public abstract class AbstractSimpleNodeDate extends AbstractSimpleNode  {
 	private static final long serialVersionUID = -7383419011106091654L;
 
@@ -19,7 +21,8 @@ public abstract class AbstractSimpleNodeDate extends AbstractSimpleNode  {
 	}
 	
 	
-	private final static DateTimeFormatter defaultDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ"); 
+	private final static DateTimeFormatter defaultDateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssZ");
+	@XmlTransient
 	public ZonedDateTime getZonedDateTime() {
 		if ((getValue() == null) || (getValue().length() == 0)) return null;
 		


### PR DESCRIPTION
AZ ran into this after we added CreatedDate and ModifiedDate to the Term class. The JDK8 JAXB implementations break on these java.time classes. Fix in this case is to just ignore this one as it's actually transient, derived from the String value field in the abstract  base class for CreatedDate and ModifiedDate.