### PR TITLE
Add SPARQL options to URL: warningsAccepted, runEditRules, and checkC…

### DIFF
--- a/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/OEBatchClient.java
+++ b/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/OEBatchClient.java
@@ -23,6 +23,7 @@ public class OEBatchClient implements Closeable {
   protected Model currentModel = null;
   protected Model pendingModel = null;
   protected BatchMode batchMode = BatchMode.None;
+  protected SparqlUpdateOptions sparqlUpdateOptions = new SparqlUpdateOptions();
 
   /**
    * Constructor for a OEBatchClient object. The OEModelEndpoint includes
@@ -107,6 +108,21 @@ public class OEBatchClient implements Closeable {
     this.pendingModel = model;
   }
 
+  /**
+   * Get the SparqlUpdateOptions config object.
+   * @return
+   */
+  public SparqlUpdateOptions getSparqlUpdateOptions() {
+    return this.sparqlUpdateOptions;
+  }
+
+  /**
+   * Set the SparqlUpdateOptions config object.
+   * @param options
+   */
+  public void setSparqlUpdateOptions(SparqlUpdateOptions options) {
+    this.sparqlUpdateOptions = options;
+  }
 
   /**
    * Reset the client by copying pending to current model. Use this if you've committed all pending changes
@@ -136,7 +152,8 @@ public class OEBatchClient implements Closeable {
         if (diff.getInLeftOnly().size() > 0 || diff.getInRightOnly().size() > 0) {
           if (logger.isDebugEnabled())
             logger.debug("Changes detected, running SPARQL Update");
-          result = endpoint.runSparqlUpdate(DiffToSparqlInsertUpdateBuilder.buildSparqlInsertUpdate(getBatchDiff()));
+          result = endpoint.runSparqlUpdate(DiffToSparqlInsertUpdateBuilder.buildSparqlInsertUpdate(getBatchDiff()),
+                                            sparqlUpdateOptions);
         } else {
           if (logger.isDebugEnabled())
             logger.debug("No changes detected in model. Not running SPARQL update.");

--- a/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/SparqlUpdateOptions.java
+++ b/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/SparqlUpdateOptions.java
@@ -1,0 +1,23 @@
+package com.smartlogic;
+
+/**
+ * Options to send with SPARQL update calls.
+ */
+public class SparqlUpdateOptions {
+
+  /**
+   * Set to true to accept constraint warnings and proceed with changes.
+   * Normally this is set to true when runCheckConstraints is set to false;
+   */
+  public boolean acceptWarnings = false;
+
+  /**
+   * Set to false to not run check constraints when running SPARQL update.
+   */
+  public boolean runCheckConstraints = true;
+
+  /**
+   * Set to false to not run edit rules when SPARQL Update is sent.
+   */
+  public boolean runEditRules = true;
+}

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ExampleClient.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ExampleClient.java
@@ -8,16 +8,32 @@ import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;
 import org.apache.jena.vocabulary.SKOSXL;
 
+import java.util.Properties;
 import java.util.UUID;
 
 public class ExampleClient {
+
   public static void main(String[] args) {
     try {
+      test1();
+      test2();
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    System.out.printf("Tests completed");
+  }
 
+  public static void test1() {
+    try {
+      Properties config = TestConfig.getConfig();
       OEModelEndpoint endpoint = new OEModelEndpoint();
-      endpoint.setBaseUrl("http://localhost:8080/swoe");
+      endpoint.setBaseUrl(config.getProperty("oeurl"));
       endpoint.setModelIRI("model:myExample");
+      endpoint.setAccessToken(config.getProperty("accesstoken"));
       try (OEBatchClient client = new OEBatchClient(endpoint)) {
+        client.getSparqlUpdateOptions().runCheckConstraints = false;
+        client.getSparqlUpdateOptions().runEditRules = false;
+        client.getSparqlUpdateOptions().acceptWarnings = true;
         client.loadCurrentModelFromOE();
         Model m = client.getPendingModel();
 
@@ -32,7 +48,7 @@ public class ExampleClient {
         c.addProperty(semGuid, UUID.randomUUID().toString());
 
         Resource cl = m.createResource("http://myexample.com/MyTestConcept1_prefLabel_en");
-        cl.addProperty(SKOSXL.literalForm, "My Test Concept 1");
+        cl.addProperty(SKOSXL.literalForm, "My Test Concept 1", "en");
         cl.addProperty(RDF.type, SKOSXL.Label);
 
         c.addProperty(SKOSXL.prefLabel, cl);
@@ -49,4 +65,52 @@ public class ExampleClient {
       e.printStackTrace();
     }
   }
+
+  public static void test2() {
+    try {
+      Properties config = TestConfig.getConfig();
+      OEModelEndpoint endpoint = new OEModelEndpoint();
+      endpoint.setBaseUrl(config.getProperty("oeurl"));
+      endpoint.setModelIRI("model:myExample");
+      endpoint.setAccessToken(config.getProperty("accesstoken"));
+      try (OEBatchClient client = new OEBatchClient(endpoint)) {
+        client.loadCurrentModelFromOE();
+        Model m = client.getPendingModel();
+
+        Property semGuid = m.createProperty("http://www.smartlogic.com/2014/08/semaphore-core#guid");
+        Resource r = m.createResource("http://myexample.com/Scheme4");
+        r.addProperty(RDF.type, SKOS.ConceptScheme);
+        r.addProperty(RDFS.label, "Test Scheme 4 (Test)");
+        r.addProperty(semGuid, UUID.randomUUID().toString());
+
+        Resource c = m.createResource("http://myexample.com/MyTestConcept2");
+        c.addProperty(RDF.type, SKOS.Concept);
+        c.addProperty(semGuid, UUID.randomUUID().toString());
+
+        Resource cl = m.createResource("http://myexample.com/MyTestConcept2_prefLabel_en");
+        cl.addProperty(SKOSXL.literalForm, "My Test Concept 1", "en");
+        cl.addProperty(RDF.type, SKOSXL.Label);
+
+        c.addProperty(SKOSXL.prefLabel, cl);
+
+        r.addProperty(SKOS.hasTopConcept, c);
+
+        // this test should error out unless check constraints are disabled...
+        if (false == client.commit()) {
+          System.out.println("Failed as expected due to duplicate English concept label created during test1");
+        } else {
+          throw new RuntimeException("Should have failed on constraint violation!");
+        }
+        // check result manually
+
+      } catch (Exception e) {
+        System.out.println("Successfully caught exception from commit! Text:" + e.getMessage());
+      } finally {
+
+      }
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+
 }

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ExampleClientWithProxy.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ExampleClientWithProxy.java
@@ -8,6 +8,7 @@ import org.apache.jena.vocabulary.RDFS;
 import org.apache.jena.vocabulary.SKOS;
 import org.apache.jena.vocabulary.SKOSXL;
 
+import java.util.Properties;
 import java.util.UUID;
 
 public class ExampleClientWithProxy {
@@ -15,12 +16,13 @@ public class ExampleClientWithProxy {
     try {
 
       OEModelEndpoint endpoint = new OEModelEndpoint();
-      endpoint.setBaseUrl("http://localhost:8080/Semaphore-4.1.20-SemaphoreWorkbenchOntologyEditor");
-      endpoint.setModelIRI("model:Playpen");
-      endpoint.setProxyHost("localhost");
-      endpoint.setProxyPort(8888);
-      endpoint.setAccessToken("WyJBZG1pbmlzdHJhdG9yIiwxNTI3NjgyNTA5LCJNQ0FDRGo1T2MzR1NoK3NIUHlWYkQ4U2ZBZzVVNXpQMnRFL0YrUVZCeWEzajB3PT0iXQ==");
+      Properties config = TestConfig.getConfig();
 
+      endpoint.setBaseUrl(config.getProperty("oeurl"));
+      endpoint.setModelIRI("model:Playpen");
+      endpoint.setProxyHost(config.getProperty("proxyhost"));
+      endpoint.setProxyPort(Integer.valueOf(config.getProperty("proxyport")));
+      endpoint.setAccessToken(config.getProperty("accesstoken"));
       try (OEBatchClient client = new OEBatchClient(endpoint)) {
         client.loadCurrentModelFromOE();
         Model m = client.getPendingModel();

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ExampleReadClient.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ExampleReadClient.java
@@ -1,0 +1,40 @@
+package com.smartlogic;
+
+import org.apache.jena.query.QuerySolution;
+import org.apache.jena.query.ResultSet;
+
+import java.util.Properties;
+
+public class ExampleReadClient {
+
+  public static void main(String[] args) {
+    test1();
+  }
+
+  public static void test1() {
+    try {
+      Properties config = TestConfig.getConfig();
+      OEModelEndpoint endpoint = new OEModelEndpoint();
+      endpoint.setBaseUrl(config.getProperty("oeurl"));
+      endpoint.setModelIRI("model:myExample");
+      endpoint.setAccessToken(config.getProperty("accesstoken"));
+
+      String sparqlUrl = endpoint.buildSPARQLUrl(null);
+      ResultSet rs = endpoint.runSparqlQuery("select ?s ?p ?o where { ?s ?p ?o . } LIMIT 100");
+      while (rs.hasNext()) {
+        QuerySolution sol = rs.next();
+        System.out.println(sol.toString());
+      }
+
+      String sparqlUrl2 = endpoint.buildSPARQLUrl();
+      ResultSet rs2 = endpoint.runSparqlQuery("select ?s ?p ?o where { ?s ?p ?o . } LIMIT 100");
+      while (rs2.hasNext()) {
+        QuerySolution sol = rs2.next();
+        System.out.println(sol.toString());
+      }
+
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+  }
+}

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ModelLoaderTests.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/ModelLoaderTests.java
@@ -1,9 +1,5 @@
 package com.smartlogic;
 
-import static junit.framework.TestCase.assertTrue;
-
-import java.io.File;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.StmtIterator;
@@ -12,6 +8,10 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.File;
+
+import static junit.framework.TestCase.assertTrue;
 
 public class ModelLoaderTests {
   @BeforeClass

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/OEBatchClientTests.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/OEBatchClientTests.java
@@ -1,13 +1,18 @@
 package com.smartlogic;
 
 import com.smartlogic.rdfdiff.RDFDifference;
+
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.riot.system.IRIResolver;
 import org.apache.jena.vocabulary.RDF;
 import org.apache.jena.vocabulary.SKOS;
-import org.junit.*;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/OEModelEndpointTests.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/OEModelEndpointTests.java
@@ -1,7 +1,5 @@
 package com.smartlogic;
 
-import static org.junit.Assert.assertEquals;
-
 import org.apache.jena.query.QueryFactory;
 import org.apache.jena.rdf.model.ModelFactory;
 import org.apache.jena.riot.system.IRIResolver;
@@ -12,6 +10,8 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class OEModelEndpointTests {
 
@@ -39,7 +39,7 @@ public class OEModelEndpointTests {
     ep.setBaseUrl("http://localhost:8080/swoe/");
 
     assertEquals(ep.buildApiUrl().toString(), "http://localhost:8080/swoe/api/t/ACCESSTOKEN");
-    assertEquals(ep.buildSPARQLUrl().toString(),
+    assertEquals(ep.buildSPARQLUrl(null).toString(),
         "http://localhost:8080/swoe/api/t/ACCESSTOKEN/model:ModelID/sparql");
   }
 

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/TestConfig.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/TestConfig.java
@@ -1,0 +1,18 @@
+package com.smartlogic;
+
+import java.io.InputStream;
+import java.util.Properties;
+
+public class TestConfig {
+
+  public static Properties getConfig() {
+
+    Properties props = new Properties();
+    try (InputStream input = TestConfig.class.getClassLoader().getResourceAsStream("testconfig.properties")) {
+      props.load(input);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    return props;
+  }
+}

--- a/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/rdfdiff/DiffToSparqlInsertUpdateBuilderTests.java
+++ b/Semaphore-OE-Batch-Tools/src/test/java/com/smartlogic/rdfdiff/DiffToSparqlInsertUpdateBuilderTests.java
@@ -1,13 +1,5 @@
 package com.smartlogic.rdfdiff;
 
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.List;
-
 import org.apache.jena.datatypes.xsd.XSDDatatype;
 import org.apache.jena.datatypes.xsd.XSDDateTime;
 import org.apache.jena.ext.com.google.common.collect.Lists;
@@ -27,6 +19,14 @@ import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.List;
+
+import static org.junit.Assert.assertTrue;
 
 public class DiffToSparqlInsertUpdateBuilderTests {
 

--- a/Semaphore-OE-Batch-Tools/src/test/resources/logback.xml
+++ b/Semaphore-OE-Batch-Tools/src/test/resources/logback.xml
@@ -32,6 +32,7 @@
 	<logger name="org.apache" level="WARN" />
 	<logger name="org.springframework" level="WARN" />
 	<logger name="com.smartlogic" level="DEBUG" />
+    <logger name="org.apache.http" level="WARN" />
 
     <root level="INFO">
         <appender-ref ref="STDOUT"/>

--- a/Semaphore-OE-Batch-Tools/src/test/resources/testconfig.properties
+++ b/Semaphore-OE-Batch-Tools/src/test/resources/testconfig.properties
@@ -1,0 +1,4 @@
+accesstoken=WyJBZG1pbmlzdHJhdG9yIiwxODUyNTk4Mzc0LCJNQ0VDRGkwZ0lycjExWENpNE9vKzlvK01BZzhBMEpLY3o2VWxkbkgvRGZ6eFcyQT0iXQ%3D%3D
+oeurl=http://localhost:8080/swoe
+proxyhost=localhost
+proxyport=8888


### PR DESCRIPTION
…onstraints.

Clients can now control whether OE runs checkConstraints and edit rules, or accept constraint warnings
by modifying the SparqlUpdateOptions object in OEBatchClient.
(At some point the default behavior changed for these, so this makes runEditRules and checkConstraints explicit.)
Tested with 4.1.26, will test with 4.2 soon.
Add org.apache.http logger explicitly so easy to switch to DEBUG to see wire interactions.
Move test config to properties file for each switching of tokens, etc.