### PR TITLE
Remove masking type declaration for idleConnectionManagerThread

### DIFF
--- a/Semaphore-CS-Client/src/main/java/com/smartlogic/classificationserver/client/ClassificationClient.java
+++ b/Semaphore-CS-Client/src/main/java/com/smartlogic/classificationserver/client/ClassificationClient.java
@@ -791,7 +791,7 @@ public class ClassificationClient {
 		
 		
 		// Make sure that idle and stale connections are discarded
-		IdleConnectionMonitorThread idleConnectionMonitorThread = new IdleConnectionMonitorThread(poolingConnectionManager);
+		idleConnectionMonitorThread = new IdleConnectionMonitorThread(poolingConnectionManager);
 		idleConnectionMonitorThread.start();
 		
 		RequestConfig.Builder requestConfigBuilder = RequestConfig.copy(RequestConfig.DEFAULT)


### PR DESCRIPTION
variable. This variable is defined for the class and is used to shutdown
the connection pool when client.close() called. The masked variable
causes this reference to orphan and hang apps when they call
client.close(). (Terminating the JVM is the only way to stop the thread)