### PR TITLE
SparqlUpdateOptions setter/is-er

### DIFF
--- a/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/SparqlUpdateOptions.java
+++ b/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/SparqlUpdateOptions.java
@@ -20,4 +20,28 @@ public class SparqlUpdateOptions {
    * Set to false to not run edit rules when SPARQL Update is sent.
    */
   public boolean runEditRules = true;
+
+  public boolean isAcceptWarnings() {
+    return acceptWarnings;
+  }
+
+  public void setAcceptWarnings(boolean acceptWarnings) {
+    this.acceptWarnings = acceptWarnings;
+  }
+
+  public boolean isRunCheckConstraints() {
+    return runCheckConstraints;
+  }
+
+  public void setRunCheckConstraints(boolean runCheckConstraints) {
+    this.runCheckConstraints = runCheckConstraints;
+  }
+
+  public boolean isRunEditRules() {
+    return runEditRules;
+  }
+
+  public void setRunEditRules(boolean runEditRules) {
+    this.runEditRules = runEditRules;
+  }
 }


### PR DESCRIPTION
Add is-ers/setters, because Java is a very verbose language and Spring is inflexible.

Leaving class variables public as they can also be used by clients that don't require bean accessors, or those that are already using them.