### PR TITLE
Update OEClientReadOnly.java - remove extra slash in path

### DIFF
--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
@@ -181,7 +181,7 @@ public class OEClientReadOnly {
 	public Collection<Model> getAllModels() throws OEClientException {
 		logger.info("getAllModels entry");
 		
-		String url = getApiURL() + "/sys/sys:Model/rdf:instance";
+		String url = getApiURL() + "sys/sys:Model/rdf:instance";
 		logger.info("getAllModels URL: {}", url);
 		Map<String, String> queryParameters = new HashMap<String, String>();
 		queryParameters.put("properties", "meta:displayName,meta:graphUri");


### PR DESCRIPTION
Remove extra slash that breaks this call in newer versions of OE which doesn't like "//sys" after the token.