### PR TITLE
Some cleanup: use WordUtils from commons-text rather than commons-lan…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ target
 /**/test-output
 /**/target
 
+/.java-version

--- a/Semaphore-CS-Client/src/test/java/com/smartlogic/classificationserver/client/ClassificationTestCase.java
+++ b/Semaphore-CS-Client/src/test/java/com/smartlogic/classificationserver/client/ClassificationTestCase.java
@@ -11,6 +11,7 @@ public abstract class ClassificationTestCase {
 	protected static ClassificationClient classificationClient;
 	protected static Map<String, Object> config;
 
+	@SuppressWarnings("unchecked")
 	public void initConfig() {
 		if (config != null)
 			return;

--- a/Semaphore-OE-Batch-Tools/pom.xml
+++ b/Semaphore-OE-Batch-Tools/pom.xml
@@ -37,5 +37,23 @@
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.10</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-text -->
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.8</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
     </dependencies>
 </project>

--- a/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/tools/LabelForUriManglator.java
+++ b/Semaphore-OE-Batch-Tools/src/main/java/com/smartlogic/tools/LabelForUriManglator.java
@@ -6,7 +6,7 @@ import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.regex.Pattern;
 
-import org.apache.commons.lang3.text.WordUtils;
+import org.apache.commons.text.WordUtils;
 import org.apache.jena.ext.com.google.common.base.CharMatcher;
 import org.apache.jena.ext.com.google.common.base.Strings;
 import org.apache.jena.ext.com.google.common.collect.ImmutableMap;

--- a/Semaphore-SES-Client/src/test/java/com/smartlogic/ses/client/ConfigUtil.java
+++ b/Semaphore-SES-Client/src/test/java/com/smartlogic/ses/client/ConfigUtil.java
@@ -11,6 +11,7 @@ public class ConfigUtil {
 	private static SESClient sesClient = getSESClient();
 	protected static Map<String, Object> config;
 
+	@SuppressWarnings("unchecked")
 	public static void initConfig() {
 		if (config != null)
 			return;


### PR DESCRIPTION
…g3 (deprecation). Suppress unchecked warnings for yaml config loads.

Add commons-text to pom for batch client, exclude old lang3 version (newest loaded by jena-libs)
Add an ignore (jenv on mac)