### PR TITLE
Add language-neutral label support to concept scheme via Label object and SemaphoreModel object.

### DIFF
--- a/Semaphore-Model-Manipulation/src/main/java/com/smartlogic/semaphoremodel/Label.java
+++ b/Semaphore-Model-Manipulation/src/main/java/com/smartlogic/semaphoremodel/Label.java
@@ -1,10 +1,10 @@
 package com.smartlogic.semaphoremodel;
 
-import java.net.URI;
-import java.net.URISyntaxException;
-
 import org.apache.jena.rdf.model.Literal;
 import org.apache.jena.rdf.model.Resource;
+
+import java.net.URI;
+import java.net.URISyntaxException;
 
 public class Label {
 
@@ -58,6 +58,6 @@ public class Label {
 	}
 
 	public String getLanguageCode() {
-		return language.getCode();
+		return language == null ? null : language.getCode();
 	}
 }

--- a/Semaphore-Model-Manipulation/src/main/java/com/smartlogic/semaphoremodel/ObjectWithURI.java
+++ b/Semaphore-Model-Manipulation/src/main/java/com/smartlogic/semaphoremodel/ObjectWithURI.java
@@ -1,19 +1,13 @@
 package com.smartlogic.semaphoremodel;
 
-import java.net.URI;
-import java.util.Base64;
-
-import org.apache.jena.query.ParameterizedSparqlString;
-import org.apache.jena.query.Query;
-import org.apache.jena.query.QueryExecution;
-import org.apache.jena.query.QueryExecutionFactory;
-import org.apache.jena.query.QueryFactory;
-import org.apache.jena.query.QuerySolution;
-import org.apache.jena.query.ResultSet;
+import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import org.apache.jena.update.UpdateAction;
 import org.apache.jena.vocabulary.RDFS;
+
+import java.net.URI;
+import java.util.Base64;
 
 
 public abstract class ObjectWithURI {
@@ -55,7 +49,8 @@ public abstract class ObjectWithURI {
 		ParameterizedSparqlString parameterizedSparql = new ParameterizedSparqlString(model);
 		parameterizedSparql.setCommandText(sparql);
 		parameterizedSparql.setParam("objectURI", resource);
-		parameterizedSparql.setParam("labelLanguage", model.createLiteral(language.getCode(), ""));
+		parameterizedSparql.setParam("labelLanguage",
+				(language == null ? model.createLiteral("") : model.createLiteral(language.getCode(), "")));
 		
 		Query query = QueryFactory.create(parameterizedSparql.asQuery());
 

--- a/Semaphore-Model-Manipulation/src/main/java/com/smartlogic/semaphoremodel/SemaphoreModel.java
+++ b/Semaphore-Model-Manipulation/src/main/java/com/smartlogic/semaphoremodel/SemaphoreModel.java
@@ -1,6 +1,7 @@
 package com.smartlogic.semaphoremodel;
 
 import org.apache.commons.io.FileUtils;
+import org.apache.jena.ext.com.google.common.base.Strings;
 import org.apache.jena.query.*;
 import org.apache.jena.rdf.model.*;
 import org.apache.jena.tdb.TDBFactory;
@@ -82,14 +83,18 @@ public class SemaphoreModel {
 	}
 
 	/**
-	 * Construct and return Jena Literal object from the spefified Jena model using the specified
-	 * label.
+	 * Construct and return Jena Literal object from the specified Jena model using the specified
+	 * label. The language code in the label can be null, indicating no language code for the literal.
 	 * @param model the Jena model to use to construct the Resource object.
 	 * @param prefLabel the label object from which to construct the Jena Literal object.
 	 * @return the Jena Literal object.
 	 */
 	protected static Literal getAsLiteral(Model model, Label prefLabel) {
-		return model.createLiteral(prefLabel.getValue(), prefLabel.getLanguageCode()).asLiteral();
+		if (Strings.isNullOrEmpty(prefLabel.getLanguageCode())) {
+			return model.createLiteral(prefLabel.getValue());
+		} else {
+			return model.createLiteral(prefLabel.getValue(), prefLabel.getLanguageCode());
+		}
 	}
 
 	/**

--- a/Semaphore-Model-Manipulation/src/test/java/com/smartlogic/semaphoremodel/TestModelBuilder.java
+++ b/Semaphore-Model-Manipulation/src/test/java/com/smartlogic/semaphoremodel/TestModelBuilder.java
@@ -48,7 +48,7 @@ public class TestModelBuilder {
 
 		semaphoreModel.createAssociativeRelationshipType(new URI("http://kma.com/RT1"), new Label("RT1", english), new URI("http://kma.com/iRT1"), new Label("iRT1", english));
 		semaphoreModel.createAssociativeRelationshipType(new URI("http://kma.com/RT2"), new Label("RT2", english), new URI("http://kma.com/iRT2"), new Label("iRT2", english), conceptClass1, conceptClass2);
-		semaphoreModel.write(new File("C:/temp/model.ttl"));
+		semaphoreModel.write(new File("src/test/resources/temp/model.ttl"));
 	}
 
 }


### PR DESCRIPTION
Fix label sparql to properly honor lang-neutral query.
Add additional tests to concept scheme (check that GUID passed during creation is used, etc)