### PR TITLE
AB#36570 Ability to pass transaction messages

### DIFF
--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
@@ -9,6 +9,7 @@ import java.net.http.HttpResponse;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 
+import com.google.gson.Gson;
 import com.smartlogic.cloud.Token;
 import com.smartlogic.ontologyeditor.beans.*;
 import org.apache.commons.lang3.StringUtils;
@@ -169,6 +170,99 @@ public class OEClientReadOnly {
   }
   public void setKRTClient(boolean krtClient) {
     isKRTClient = krtClient;
+  }
+
+  private String operationSource;
+
+  public String getOperationSource() {
+    return operationSource;
+  }
+
+  /**
+   * Set a persistent label identifying who/what is driving operations through this client
+   * instance (e.g. "KMM AI Assistant" for an MCP server, or a username for a direct user action).
+   * When set, it is automatically appended as {@code " (via {operationSource})"} to any simple
+   * text transaction message set via {@link #setTransactionMessage(String)}.
+   *
+   * @param operationSource - the label to append to transaction messages, or {@code null} to stop appending one
+   */
+  public void setOperationSource(String operationSource) {
+    this.operationSource = operationSource;
+  }
+
+  private String transactionMessage;
+  private String transactionMessageJson;
+
+  /**
+   * Attach a simple text transaction message to the next modifying request (POST/PATCH/DELETE)
+   * issued by this client. This message is persisted in history and visible when changes are
+   * later retrieved. The message is one-shot: it is consumed (cleared) once the request has been
+   * sent, whether the operationSource suffix (see {@link #setOperationSource(String)}) is applied
+   * or not.
+   *
+   * @param message - the free text transaction message
+   */
+  public void setTransactionMessage(String message) {
+    this.transactionMessage = message;
+    this.transactionMessageJson = null;
+  }
+
+  /**
+   * Attach a structured (translatable) transaction message to the next modifying request
+   * (POST/PATCH/DELETE) issued by this client, built from a template key and its parameters. See
+   * TransactionMessages.properties for the available template keys. The message is one-shot: it
+   * is consumed (cleared) once the request has been sent.
+   *
+   * @param templateKey - key used to look up the message template
+   * @param params - parameters required by the given template
+   */
+  public void setTransactionMessage(String templateKey, List<Object> params) {
+    Map<String, Object> messageMap = new LinkedHashMap<>();
+    messageMap.put("templateKey", templateKey);
+    messageMap.put("params", params);
+    this.transactionMessageJson = new Gson().toJson(messageMap);
+    this.transactionMessage = null;
+  }
+
+  /**
+   * Attach an already-built structured transaction message (raw JSON, matching the
+   * {@code X-Transaction-Message-Json} contract) to the next modifying request issued by this
+   * client. The message is one-shot: it is consumed (cleared) once the request has been sent.
+   *
+   * @param transactionMessageJson - raw JSON with {@code templateKey} and {@code params} keys
+   */
+  public void setTransactionMessageJson(String transactionMessageJson) {
+    this.transactionMessageJson = transactionMessageJson;
+    this.transactionMessage = null;
+  }
+
+  /**
+   * Clear any transaction message previously set via {@link #setTransactionMessage(String)},
+   * {@link #setTransactionMessage(String, List)} or {@link #setTransactionMessageJson(String)}
+   * without sending a request.
+   */
+  public void clearTransactionMessage() {
+    this.transactionMessage = null;
+    this.transactionMessageJson = null;
+  }
+
+  /**
+   * Apply, then consume (one-shot), any pending transaction message onto a request about to be
+   * sent. Only relevant for modifying requests (POST/PATCH/DELETE); harmless no-op otherwise.
+   *
+   * @param requestBuilder - the request builder for the outgoing modifying request
+   */
+  protected void applyTransactionMessageHeaders(HttpRequest.Builder requestBuilder) {
+    if (transactionMessageJson != null) {
+      requestBuilder.header("X-Transaction-Message-Json", transactionMessageJson);
+    } else if (StringUtils.isNotEmpty(transactionMessage)) {
+      String messageToSend = transactionMessage;
+      if (StringUtils.isNotBlank(operationSource)) {
+        messageToSend = messageToSend + " (via " + operationSource + ")";
+      }
+      requestBuilder.header("X-Transaction-Message", messageToSend);
+    }
+    clearTransactionMessage();
   }
 
   protected String getWrappedUri(String uriString) throws OEClientException {
@@ -1111,6 +1205,7 @@ public class OEClientReadOnly {
     HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(URI.create(urlToUse))
             .header("Accept", "application/ld+json,application/json");
     addHeaders(requestBuilder);
+    applyTransactionMessageHeaders(requestBuilder);
 
     if (RequestType.POST == requestType) {
       requestBuilder.method("POST", bodyPublisher)

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
@@ -182,12 +182,13 @@ public class OEClientReadOnly {
    * Set a persistent label identifying who/what is driving operations through this client
    * instance (e.g. "KMM AI Assistant" for an MCP server, or a username for a direct user action).
    * When set, it is automatically appended as {@code " (via {operationSource})"} to any simple
-   * text transaction message set via {@link #setTransactionMessage(String)}.
+   * text transaction message set via {@link #setTransactionMessage(String)}. Any CR/LF characters
+   * are stripped since the value ends up in an HTTP header.
    *
    * @param operationSource - the label to append to transaction messages, or {@code null} to stop appending one
    */
   public void setOperationSource(String operationSource) {
-    this.operationSource = operationSource;
+    this.operationSource = sanitizeHeaderValue(operationSource);
   }
 
   private String transactionMessage;
@@ -196,14 +197,15 @@ public class OEClientReadOnly {
   /**
    * Attach a simple text transaction message to the next modifying request (POST/PATCH/DELETE)
    * issued by this client. This message is persisted in history and visible when changes are
-   * later retrieved. The message is one-shot: it is consumed (cleared) once the request has been
-   * sent, whether the operationSource suffix (see {@link #setOperationSource(String)}) is applied
-   * or not.
+   * later retrieved. The message is one-shot: it is consumed (cleared) once it has been applied
+   * to the outgoing request, whether the operationSource suffix (see
+   * {@link #setOperationSource(String)}) is applied or not. Any CR/LF characters are stripped
+   * since the value ends up in an HTTP header.
    *
    * @param message - the free text transaction message
    */
   public void setTransactionMessage(String message) {
-    this.transactionMessage = message;
+    this.transactionMessage = sanitizeHeaderValue(message);
     this.transactionMessageJson = null;
   }
 
@@ -211,7 +213,7 @@ public class OEClientReadOnly {
    * Attach a structured (translatable) transaction message to the next modifying request
    * (POST/PATCH/DELETE) issued by this client, built from a template key and its parameters. See
    * TransactionMessages.properties for the available template keys. The message is one-shot: it
-   * is consumed (cleared) once the request has been sent.
+   * is consumed (cleared) once it has been applied to the outgoing request.
    *
    * @param templateKey - key used to look up the message template
    * @param params - parameters required by the given template
@@ -227,12 +229,15 @@ public class OEClientReadOnly {
   /**
    * Attach an already-built structured transaction message (raw JSON, matching the
    * {@code X-Transaction-Message-Json} contract) to the next modifying request issued by this
-   * client. The message is one-shot: it is consumed (cleared) once the request has been sent.
+   * client. The message is one-shot: it is consumed (cleared) once it has been applied to the
+   * outgoing request. Any CR/LF characters are stripped since the value ends up in an HTTP
+   * header; this is safe even for pretty-printed JSON since whitespace outside of string values
+   * is not significant in JSON.
    *
    * @param transactionMessageJson - raw JSON with {@code templateKey} and {@code params} keys
    */
   public void setTransactionMessageJson(String transactionMessageJson) {
-    this.transactionMessageJson = transactionMessageJson;
+    this.transactionMessageJson = sanitizeHeaderValue(transactionMessageJson);
     this.transactionMessage = null;
   }
 
@@ -247,6 +252,22 @@ public class OEClientReadOnly {
   }
 
   /**
+   * Strip CR/LF characters from a value that will be sent as an HTTP header, since
+   * {@link HttpRequest.Builder#header(String, String)} rejects header values containing them
+   * (header injection prevention) and throws {@link IllegalArgumentException} at request build
+   * time rather than a catchable {@link OEClientException}.
+   *
+   * @param value - the candidate header value
+   * @return the value with any CR/LF characters removed, or the original value if it is {@code null}
+   */
+  private static String sanitizeHeaderValue(String value) {
+    if (value == null) {
+      return null;
+    }
+    return value.replace("\r", "").replace("\n", "");
+  }
+
+  /**
    * Apply, then consume (one-shot), any pending transaction message onto a request about to be
    * sent. Only relevant for modifying requests (POST/PATCH/DELETE); harmless no-op otherwise.
    *
@@ -255,7 +276,7 @@ public class OEClientReadOnly {
   protected void applyTransactionMessageHeaders(HttpRequest.Builder requestBuilder) {
     if (transactionMessageJson != null) {
       requestBuilder.header("X-Transaction-Message-Json", transactionMessageJson);
-    } else if (StringUtils.isNotEmpty(transactionMessage)) {
+    } else if (StringUtils.isNotBlank(transactionMessage)) {
       String messageToSend = transactionMessage;
       if (StringUtils.isNotBlank(operationSource)) {
         messageToSend = messageToSend + " (via " + operationSource + ")";

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadOnlyTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadOnlyTest.java
@@ -4,11 +4,15 @@ package com.smartlogic.ontologyeditor;
 import com.smartlogic.ontologyeditor.beans.Model;
 import org.junit.Test;
 
+import java.net.URI;
+import java.net.http.HttpRequest;
 import java.util.ArrayDeque;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.Queue;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -69,6 +73,64 @@ public class OEClientReadOnlyTest {
     } catch (OEClientException ex) {
       assertTrue(ex.getMessage().contains("Model not found: missing:model"));
     }
+  }
+
+  @Test
+  public void transactionMessageHeaderIsAppliedAndConsumed() {
+    StubReadOnlyClient client = newClient();
+    client.setTransactionMessage("New concept Created");
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(builder);
+    HttpRequest request = builder.build();
+
+    assertEquals("New concept Created", request.headers().firstValue("X-Transaction-Message").orElse(null));
+    assertFalse(request.headers().firstValue("X-Transaction-Message-Json").isPresent());
+
+    // one-shot: applying again should not resend the message
+    HttpRequest.Builder secondBuilder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(secondBuilder);
+    assertFalse(secondBuilder.build().headers().firstValue("X-Transaction-Message").isPresent());
+  }
+
+  @Test
+  public void transactionMessageHeaderAppendsOperationSourceSuffix() {
+    StubReadOnlyClient client = newClient();
+    client.setOperationSource("KMM AI Assistant");
+    client.setTransactionMessage("New concept Created");
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(builder);
+
+    assertEquals("New concept Created (via KMM AI Assistant)",
+            builder.build().headers().firstValue("X-Transaction-Message").orElse(null));
+  }
+
+  @Test
+  public void structuredTransactionMessageIsSerializedAsJson() {
+    StubReadOnlyClient client = newClient();
+    client.setTransactionMessage("concept-multiple-added", Arrays.asList(1, "http://example.com/demo-model#New-Concept"));
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(builder);
+    HttpRequest request = builder.build();
+
+    String jsonHeader = request.headers().firstValue("X-Transaction-Message-Json").orElse(null);
+    assertTrue(jsonHeader.contains("\"templateKey\":\"concept-multiple-added\""));
+    assertTrue(jsonHeader.contains("http://example.com/demo-model#New-Concept"));
+    assertFalse(request.headers().firstValue("X-Transaction-Message").isPresent());
+  }
+
+  @Test
+  public void clearTransactionMessageRemovesPendingMessage() {
+    StubReadOnlyClient client = newClient();
+    client.setTransactionMessage("Should not be sent");
+    client.clearTransactionMessage();
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(builder);
+
+    assertFalse(builder.build().headers().firstValue("X-Transaction-Message").isPresent());
   }
 
   private static StubReadOnlyClient newClient() {

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadOnlyTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadOnlyTest.java
@@ -133,6 +133,42 @@ public class OEClientReadOnlyTest {
     assertFalse(builder.build().headers().firstValue("X-Transaction-Message").isPresent());
   }
 
+  @Test
+  public void transactionMessageStripsCarriageReturnAndNewline() {
+    StubReadOnlyClient client = newClient();
+    client.setOperationSource("KMM\r\nAI Assistant");
+    client.setTransactionMessage("New concept\r\nCreated");
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(builder);
+
+    assertEquals("New conceptCreated (via KMMAI Assistant)",
+            builder.build().headers().firstValue("X-Transaction-Message").orElse(null));
+  }
+
+  @Test
+  public void rawTransactionMessageJsonStripsCarriageReturnAndNewline() {
+    StubReadOnlyClient client = newClient();
+    client.setTransactionMessageJson("{\r\n  \"templateKey\": \"concept-added\"\r\n}");
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(builder);
+
+    assertEquals("{  \"templateKey\": \"concept-added\"}",
+            builder.build().headers().firstValue("X-Transaction-Message-Json").orElse(null));
+  }
+
+  @Test
+  public void whitespaceOnlyTransactionMessageIsNotSent() {
+    StubReadOnlyClient client = newClient();
+    client.setTransactionMessage("   ");
+
+    HttpRequest.Builder builder = HttpRequest.newBuilder().uri(URI.create("http://localhost"));
+    client.applyTransactionMessageHeaders(builder);
+
+    assertFalse(builder.build().headers().firstValue("X-Transaction-Message").isPresent());
+  }
+
   private static StubReadOnlyClient newClient() {
     StubReadOnlyClient client = new StubReadOnlyClient();
     client.setBaseURL("http://localhost");


### PR DESCRIPTION
Adds support in the Semaphore Ontology Editor Java client to attach one-shot transaction message headers to outgoing modifying requests, including optional attribution (“via …”) and a structured JSON variant.