### PR TITLE
Add support for symmetric relationship types (owl:SymmetricProperty)

### DIFF
--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientRelationshipTypeIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientRelationshipTypeIT.java
@@ -42,5 +42,18 @@ public class OEClientRelationshipTypeIT extends AbstractModelScopedIT {
         .orElseThrow(() -> new AssertionError("Label relationship type not found after creation"));
   }
 
+  @Test
+  public void createSymmetricRelationshipType() throws OEClientException {
+    String symmetricUri = "http://example.test/symmetricRelType_" + UUID.randomUUID();
+    Label label = new Label("en", "Symmetric Relationship");
+
+    oeClient.createSymmetricRelationshipType(label, symmetricUri);
+
+    oeClient.getAssociativeRelationshipTypes().stream()
+        .filter(rt -> rt.getUri().equals(symmetricUri))
+        .findFirst()
+        .orElseThrow(() -> new AssertionError("Symmetric relationship type not found after creation"));
+  }
+
 }
 

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientRelationshipTypeIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientRelationshipTypeIT.java
@@ -1,12 +1,16 @@
 // Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
 package com.smartlogic.ontologyeditor;
 
+import com.smartlogic.ontologyeditor.beans.Concept;
+import com.smartlogic.ontologyeditor.beans.ConceptScheme;
 import com.smartlogic.ontologyeditor.beans.Label;
 import org.junit.Test;
 
+import java.util.List;
 import java.util.UUID;
 
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Integration tests for relationship type management.
@@ -53,6 +57,48 @@ public class OEClientRelationshipTypeIT extends AbstractModelScopedIT {
         .filter(rt -> rt.getUri().equals(symmetricUri))
         .findFirst()
         .orElseThrow(() -> new AssertionError("Symmetric relationship type not found after creation"));
+  }
+
+  @Test
+  public void symmetricRelationshipIsInstantiatedInBothDirections() throws OEClientException {
+    String symmetricUri = "http://example.test/symmetricRelType_" + UUID.randomUUID();
+    Label label = new Label("en", "Married To");
+    oeClient.createSymmetricRelationshipType(label, symmetricUri);
+
+    ConceptScheme scheme = createTestScheme();
+    Concept concept1 = createTestConcept(scheme, "Concept A");
+    Concept concept2 = createTestConcept(scheme, "Concept B");
+
+    // Only the forward direction (concept1 -> concept2) is created explicitly.
+    oeClient.createRelationship(symmetricUri, concept1, concept2);
+
+    Concept reloadedConcept1 = oeClient.getConcept(concept1.getUri());
+    Concept reloadedConcept2 = oeClient.getConcept(concept2.getUri());
+
+    assertTrue("Forward relationship should be present on concept1",
+        reloadedConcept1.getRelatedConceptUris(symmetricUri).contains(concept2.getUri()));
+    assertTrue(
+        "Because the relationship type is symmetric, concept2 should also report the reverse "
+            + "relationship back to concept1 even though it was never created explicitly",
+        reloadedConcept2.getRelatedConceptUris(symmetricUri).contains(concept1.getUri()));
+  }
+
+  private Concept createTestConcept(ConceptScheme scheme, String label) throws OEClientException {
+    Concept concept = new Concept(oeClient, generateConceptUri(), List.of(new Label("en", label)));
+    oeClient.createConcept(scheme.getUri(), concept);
+    return concept;
+  }
+
+  private ConceptScheme createTestScheme() throws OEClientException {
+    String uniqueName = "SymmetricRelTypeTestScheme_" + UUID.randomUUID().toString().substring(0, 8);
+    ConceptScheme scheme = new ConceptScheme(oeClient, "http://example.test/scheme/" + uniqueName,
+        List.of(new Label("en", uniqueName)));
+    oeClient.createConceptScheme(scheme);
+    return scheme;
+  }
+
+  private String generateConceptUri() {
+    return "http://example.test/concept/" + UUID.randomUUID();
   }
 
 }

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientRelationshipTypeIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientRelationshipTypeIT.java
@@ -9,7 +9,6 @@ import org.junit.Test;
 import java.util.List;
 import java.util.UUID;
 
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
@@ -1163,6 +1163,34 @@ public class OEClientReadWrite extends OEClientReadOnly {
 
 	}
 
+	/**
+	 * Create a new symmetric associative relationship type in the model. Unlike
+	 * {@link #createRelationshipType(Label, String, Label, String)}, a symmetric relationship type
+	 * has a single URI (it is its own inverse) and is typed as {@code owl:SymmetricProperty} in
+	 * addition to {@code owl:ObjectProperty}, so relating concept A to concept B implies the
+	 * reverse relationship B to A without needing a separate inverse relationship type.
+	 *
+	 * @param label
+	 *            the label of the symmetric relationship type
+	 * @param uri
+	 *            the URI to assign to the new relationship type
+	 */
+	public void createSymmetricRelationshipType(Label label, String uri) {
+		logger.info("createSymmetricRelationshipType entry: {} {}", label, uri);
+
+		JsonObject relationshipType = getRelationshipTypeJsonObject(label, uri, true);
+
+		String relationshipTypePayload = relationshipType.toString();
+
+		logger.info("createSymmetricRelationshipType making call  : {}", relationshipTypePayload);
+		try {
+			makeRequest(getModelURL(), relationshipTypePayload, RequestType.POST);
+		} catch (OEClientException e) {
+			logger.error("createSymmetricRelationshipType failed: {}", e.getMessage());
+		}
+
+	}
+
 	public void createLabelRelationshipType(Label forwardLabel, String forwardUri) {
 		logger.info("createLabelRelationshipType entry: {} {}", forwardLabel, forwardUri);
 
@@ -1212,12 +1240,19 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	}
 
 	private JsonObject getRelationshipTypeJsonObject(Label forwardLabel, String forwardUri) {
+		return getRelationshipTypeJsonObject(forwardLabel, forwardUri, false);
+	}
+
+	private JsonObject getRelationshipTypeJsonObject(Label forwardLabel, String forwardUri, boolean symmetric) {
 
 		JsonObject relationshipTypeObject = new JsonObject();
 
 
 		JsonArray typeArray = new JsonArray();
 		typeArray.add("owl:ObjectProperty");
+		if (symmetric) {
+			typeArray.add("owl:SymmetricProperty");
+		}
 		relationshipTypeObject.put("@type", typeArray);
 		relationshipTypeObject.put("@id", forwardUri);
 

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
@@ -447,6 +447,38 @@ public class OEClientReadWriteTest {
     assertEquals("@graph/0/dcterms:language/-", patch.get(0).getAsJsonObject().get("path").getAsString());
   }
 
+  @Test
+  public void createSymmetricRelationshipTypeIncludesSymmetricPropertyType() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Label label = new Label("en", "Related To");
+    String uri = "urn:relType:symmetric";
+
+    client.createSymmetricRelationshipType(label, uri);
+
+    assertEquals(1, client.makeRequestCallCount);
+    JsonObject payload = JSON.parse(client.lastPayload);
+    JsonArray typeArray = payload.get("@type").getAsArray();
+    List<String> types = new ArrayList<>();
+    typeArray.forEach(value -> types.add(value.getAsString().value()));
+    assertTrue("Should be typed as owl:ObjectProperty", types.contains("owl:ObjectProperty"));
+    assertTrue("Should be typed as owl:SymmetricProperty", types.contains("owl:SymmetricProperty"));
+    assertEquals(uri, payload.get("@id").getAsString().value());
+    assertNull("A symmetric relationship type must not have a separate inverse", payload.get("owl:inverseOf"));
+  }
+
+  @Test
+  public void createRelationshipTypeDoesNotIncludeSymmetricPropertyType() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Label forwardLabel = new Label("en", "Forward");
+    Label inverseLabel = new Label("en", "Inverse");
+
+    client.createRelationshipType(forwardLabel, "urn:relType:forward", inverseLabel, "urn:relType:inverse");
+
+    assertEquals(1, client.makeRequestCallCount);
+    assertFalse("Non-symmetric relationship types must not be typed as owl:SymmetricProperty",
+        client.lastPayload.contains("owl:SymmetricProperty"));
+  }
+
   private static CapturingReadWriteClient newClient() {
     CapturingReadWriteClient client = new CapturingReadWriteClient();
     client.setBaseURL("http://localhost");


### PR DESCRIPTION
Adds OEClientReadWrite.createSymmetricRelationshipType(Label, String).

## Why
Follow-up from Semaphore-kmm-ai-assistant PR #21 review: Robert asked whether symmetric relationships were instantiated in both directions. Investigation showed the OE-Client Java API had no support for owl:SymmetricProperty at all.

## What changed
- New createSymmetricRelationshipType(Label, String): creates a single associative relationship type tagged with both owl:ObjectProperty and owl:SymmetricProperty (plus subPropertyOf skos:related, so it's discoverable via getAssociativeRelationshipTypes() like other associative types). No separate owl:inverseOf entry is added, since a symmetric property is its own inverse.
- getRelationshipTypeJsonObject refactored with an optional symmetric flag, reused by both createRelationshipType and the new method.
- Unit tests verifying the JSON-LD payload includes owl:SymmetricProperty (and omits owl:inverseOf) for the new method, and that the existing createRelationshipType payload is unaffected.
- Integration test creating a symmetric relationship type and verifying it's returned by getAssociativeRelationshipTypes().

## Testing
mvn -pl Semaphore-OE-Client -am test -> BUILD SUCCESS, 46/46 tests passing.