### PR TITLE
AB#37469 Add model/task settings update APIs (namespace, color, tags, roles)

### DIFF
--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/AbstractModelScopedIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/AbstractModelScopedIT.java
@@ -37,9 +37,13 @@ public abstract class AbstractModelScopedIT extends AbstractOEIntegrationTest {
         }
         String modelLabel = "OE_CLIENT_EXAMPLE_" + getClass().getCanonicalName() + "_" + UUID.randomUUID().toString().replace("-", "").substring(0, 16);
         String modelUri = "model:" + modelLabel;
-        testModel = new Model(modelUri, new Label("", modelLabel), null);
-        oeClient.createModel(testModel);
-        oeClient.setModelUri(testModel.getUri());
+        Model modelToCreate = new Model(modelUri, new Label("", modelLabel), null,
+                "http://example.test/" + modelLabel + "#");
+        oeClient.createModel(modelToCreate);
+        oeClient.setModelUri(modelUri);
+        // Re-fetch from the server so testModel.getDefaultNamespace() (and getComment())
+        // reflect the real, server-assigned values instead of the value we supplied at creation.
+        testModel = oeClient.getModel(modelUri);
     }
 
     /**

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/AbstractModelScopedIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/AbstractModelScopedIT.java
@@ -3,9 +3,17 @@ package com.smartlogic.ontologyeditor;
 
 import com.smartlogic.ontologyeditor.beans.Label;
 import com.smartlogic.ontologyeditor.beans.Model;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
 import org.junit.After;
 import org.junit.Before;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 /**
@@ -63,6 +71,61 @@ public abstract class AbstractModelScopedIT extends AbstractOEIntegrationTest {
                 testModel = null;
             }
         }
+    }
+
+    /**
+     * Fetches the current values of a single property of the resource (model or task) at
+     * {@code sysGraphUri} directly from the API, bypassing any bean mapping. Shared by IT tests
+     * that need to assert on the raw server state of a model or task setting (e.g. {@code
+     * rdfs:comment}, {@code swa:defaultNamespace}, {@code sem:color}, {@code sem:tag},
+     * {@code sempermissions:*}) after a mutation, since {@link Model}/{@code Task} only expose a
+     * subset of these as typed fields.
+     *
+     * @param sysGraphUri the model URI or task graph URI to query, e.g. {@code testModel.getUri()}
+     *        or {@code testTask.getGraphUri()}
+     * @param propertyUri the JSON-LD property to fetch, e.g. {@code "rdfs:comment"}
+     * @return the property's current values (empty if the resource or property is absent)
+     */
+    protected List<String> getPropertyValues(String sysGraphUri, String propertyUri) throws OEClientException {
+        Map<String, String> queryParameters = new HashMap<>();
+        queryParameters.put(OEClientReadOnly.PARAM_PROPERTIES, propertyUri);
+
+        String url = oeClient.getApiURL() + "sys/" + sysGraphUri;
+        String response = oeClient.getResponse(url, queryParameters);
+
+        JsonObject jsonResponse = JSON.parse(response);
+        JsonArray graph = jsonResponse.get(OEClientReadOnly.JSON_LD_GRAPH).getAsArray();
+
+        List<String> values = new ArrayList<>();
+        if (graph.size() == 0) {
+            return values;
+        }
+
+        JsonObject resourceObject = graph.get(0).getAsObject();
+        JsonValue propertyValue = resourceObject.get(propertyUri);
+        if (propertyValue == null) {
+            return values;
+        }
+
+        if (propertyValue.isArray()) {
+            propertyValue.getAsArray().forEach(value -> values.add(extractValue(value)));
+        } else {
+            values.add(extractValue(propertyValue));
+        }
+        return values;
+    }
+
+    private String extractValue(JsonValue value) {
+        if (value.isObject() && value.getAsObject().get("@value") != null) {
+            return value.getAsObject().get("@value").getAsString().value();
+        }
+        if (value.isObject() && value.getAsObject().get("@id") != null) {
+            return value.getAsObject().get("@id").getAsString().value();
+        }
+        if (value.isString()) {
+            return value.getAsString().value();
+        }
+        return value.toString();
     }
 }
 

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/AbstractOEIntegrationTest.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/AbstractOEIntegrationTest.java
@@ -42,7 +42,7 @@ public abstract class AbstractOEIntegrationTest {
             token = System.getenv("OE_TOKEN");
         }
         if (token != null && !token.isBlank()) {
-            oeClient.setToken(token);
+            oeClient.setHeaderToken(token);
         }
 
         String tokenUrl = System.getProperty("OE_TOKEN_URL");

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelManagementIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelManagementIT.java
@@ -27,7 +27,8 @@ public class OEClientModelManagementIT extends AbstractModelScopedIT {
     oeClient.createConceptScheme(new ConceptScheme(oeClient, "http://example.test/schemeForLinking", List.of(new Label("en", "Scheme for Linking"))));
     String modelLabel = "OE_CLIENT_EXAMPLE_" + UUID.randomUUID().toString().replace("-", "").substring(0, 8);
     String modelUri = "model:" + modelLabel;
-    Model linkedModel = new Model(modelUri, new Label("", modelLabel), null);
+    Model linkedModel = new Model(modelUri, new Label("", modelLabel), null,
+        "http://example.test/" + modelLabel + "#");
     oeClient.createModel(linkedModel);
 
     try {

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelSettingsIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelSettingsIT.java
@@ -1,16 +1,9 @@
 // Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
 package com.smartlogic.ontologyeditor;
 
-import org.apache.jena.atlas.json.JSON;
-import org.apache.jena.atlas.json.JsonArray;
-import org.apache.jena.atlas.json.JsonObject;
-import org.apache.jena.atlas.json.JsonValue;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
@@ -97,44 +90,6 @@ public class OEClientModelSettingsIT extends AbstractModelScopedIT {
    * a fixed subset of properties).
    */
   private List<String> getModelPropertyValues(String propertyUri) throws OEClientException {
-    Map<String, String> queryParameters = new HashMap<>();
-    queryParameters.put(OEClientReadOnly.PARAM_PROPERTIES, propertyUri);
-
-    String url = oeClient.getApiURL() + "sys/" + testModel.getUri();
-    String response = oeClient.getResponse(url, queryParameters);
-
-    JsonObject jsonResponse = JSON.parse(response);
-    JsonArray graph = jsonResponse.get(OEClientReadOnly.JSON_LD_GRAPH).getAsArray();
-
-    List<String> values = new ArrayList<>();
-    if (graph.size() == 0) {
-      return values;
-    }
-
-    JsonObject modelObject = graph.get(0).getAsObject();
-    JsonValue propertyValue = modelObject.get(propertyUri);
-    if (propertyValue == null) {
-      return values;
-    }
-
-    if (propertyValue.isArray()) {
-      propertyValue.getAsArray().forEach(value -> values.add(extractValue(value)));
-    } else {
-      values.add(extractValue(propertyValue));
-    }
-    return values;
-  }
-
-  private String extractValue(JsonValue value) {
-    if (value.isObject() && value.getAsObject().get("@value") != null) {
-      return value.getAsObject().get("@value").getAsString().value();
-    }
-    if (value.isObject() && value.getAsObject().get("@id") != null) {
-      return value.getAsObject().get("@id").getAsString().value();
-    }
-    if (value.isString()) {
-      return value.getAsString().value();
-    }
-    return value.toString();
+    return getPropertyValues(testModel.getUri(), propertyUri);
   }
 }

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelSettingsIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelSettingsIT.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -30,6 +31,19 @@ public class OEClientModelSettingsIT extends AbstractModelScopedIT {
     List<String> comments = getModelPropertyValues("rdfs:comment");
     assertTrue(comments.contains("Updated description"));
     assertFalse(comments.contains("Initial description"));
+  }
+
+  @Test
+  public void getModelReturnsCurrentCommentAndDefaultNamespace() throws OEClientException {
+    oeClient.updateModelComment(testModel, null, "Description for getModel");
+    String newNamespace = "http://example.test/" + UUID.randomUUID() + "#";
+    oeClient.updateModelDefaultNamespace(testModel, testModel.getDefaultNamespace(),
+        newNamespace);
+
+    com.smartlogic.ontologyeditor.beans.Model refetched = oeClient.getModel(testModel.getUri());
+
+    assertEquals("Description for getModel", refetched.getComment());
+    assertEquals(newNamespace, refetched.getDefaultNamespace());
   }
 
   @Test

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelSettingsIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientModelSettingsIT.java
@@ -1,0 +1,126 @@
+// Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
+package com.smartlogic.ontologyeditor;
+
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for updating model settings: comment, default namespace, color and tags.
+ */
+public class OEClientModelSettingsIT extends AbstractModelScopedIT {
+
+  @Test
+  public void updateModelCommentAddsAndReplacesComment() throws OEClientException {
+    oeClient.updateModelComment(testModel, null, "Initial description");
+    assertTrue(getModelPropertyValues("rdfs:comment").contains("Initial description"));
+
+    oeClient.updateModelComment(testModel, "Initial description", "Updated description");
+    List<String> comments = getModelPropertyValues("rdfs:comment");
+    assertTrue(comments.contains("Updated description"));
+    assertFalse(comments.contains("Initial description"));
+  }
+
+  @Test
+  public void updateModelDefaultNamespaceReplacesNamespace() throws OEClientException {
+    String oldNamespace = testModel.getDefaultNamespace();
+    String newNamespace = "http://example.test/" + UUID.randomUUID() + "#";
+
+    oeClient.updateModelDefaultNamespace(testModel, oldNamespace, newNamespace);
+
+    List<String> namespaces = getModelPropertyValues("swa:defaultNamespace");
+    assertTrue(namespaces.contains(newNamespace));
+    assertFalse(namespaces.contains(oldNamespace));
+  }
+
+  @Test
+  public void updateModelColorAddsAndReplacesColor() throws OEClientException {
+    oeClient.updateModelColor(testModel, null, "00c851");
+    assertTrue(getModelPropertyValues("sem:color").contains("00c851"));
+
+    oeClient.updateModelColor(testModel, "00c851", "7fa38e");
+    List<String> colors = getModelPropertyValues("sem:color");
+    assertTrue(colors.contains("7fa38e"));
+    assertFalse(colors.contains("00c851"));
+  }
+
+  @Test
+  public void addAndRemoveModelTag() throws OEClientException {
+    String tag = "IT tag " + UUID.randomUUID();
+
+    oeClient.addModelTag(testModel, tag);
+    assertTrue(getModelPropertyValues("sem:tag").contains(tag));
+
+    oeClient.removeModelTag(testModel, tag);
+    assertFalse(getModelPropertyValues("sem:tag").contains(tag));
+  }
+
+  @Test
+  public void assignAndUnassignModelRole() throws OEClientException {
+    String principalUri = "role:SemaphoreUsers";
+
+    oeClient.assignModelRole(testModel, "viewer", principalUri);
+    assertTrue(getModelPropertyValues("sempermissions:viewer").contains(principalUri));
+
+    oeClient.unassignModelRole(testModel, "viewer", principalUri);
+    assertFalse(getModelPropertyValues("sempermissions:viewer").contains(principalUri));
+  }
+
+  /**
+   * Fetch the current values of a single property of the test model directly from the API,
+   * bypassing the {@link com.smartlogic.ontologyeditor.beans.Model} bean (which only exposes
+   * a fixed subset of properties).
+   */
+  private List<String> getModelPropertyValues(String propertyUri) throws OEClientException {
+    Map<String, String> queryParameters = new HashMap<>();
+    queryParameters.put(OEClientReadOnly.PARAM_PROPERTIES, propertyUri);
+
+    String url = oeClient.getApiURL() + "sys/" + testModel.getUri();
+    String response = oeClient.getResponse(url, queryParameters);
+
+    JsonObject jsonResponse = JSON.parse(response);
+    JsonArray graph = jsonResponse.get(OEClientReadOnly.JSON_LD_GRAPH).getAsArray();
+
+    List<String> values = new ArrayList<>();
+    if (graph.size() == 0) {
+      return values;
+    }
+
+    JsonObject modelObject = graph.get(0).getAsObject();
+    JsonValue propertyValue = modelObject.get(propertyUri);
+    if (propertyValue == null) {
+      return values;
+    }
+
+    if (propertyValue.isArray()) {
+      propertyValue.getAsArray().forEach(value -> values.add(extractValue(value)));
+    } else {
+      values.add(extractValue(propertyValue));
+    }
+    return values;
+  }
+
+  private String extractValue(JsonValue value) {
+    if (value.isObject() && value.getAsObject().get("@value") != null) {
+      return value.getAsObject().get("@value").getAsString().value();
+    }
+    if (value.isObject() && value.getAsObject().get("@id") != null) {
+      return value.getAsObject().get("@id").getAsString().value();
+    }
+    if (value.isString()) {
+      return value.getAsString().value();
+    }
+    return value.toString();
+  }
+}

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientTaskSettingsIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientTaskSettingsIT.java
@@ -3,17 +3,10 @@ package com.smartlogic.ontologyeditor;
 
 import com.smartlogic.ontologyeditor.beans.Label;
 import com.smartlogic.ontologyeditor.beans.Task;
-import org.apache.jena.atlas.json.JSON;
-import org.apache.jena.atlas.json.JsonArray;
-import org.apache.jena.atlas.json.JsonObject;
-import org.apache.jena.atlas.json.JsonValue;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
@@ -88,44 +81,6 @@ public class OEClientTaskSettingsIT extends AbstractModelScopedIT {
    * Fetch the current values of a single property of the test task directly from the API.
    */
   private List<String> getTaskPropertyValues(String propertyUri) throws OEClientException {
-    Map<String, String> queryParameters = new HashMap<>();
-    queryParameters.put(OEClientReadOnly.PARAM_PROPERTIES, propertyUri);
-
-    String url = oeClient.getApiURL() + "sys/" + testTask.getGraphUri();
-    String response = oeClient.getResponse(url, queryParameters);
-
-    JsonObject jsonResponse = JSON.parse(response);
-    JsonArray graph = jsonResponse.get(OEClientReadOnly.JSON_LD_GRAPH).getAsArray();
-
-    List<String> values = new ArrayList<>();
-    if (graph.size() == 0) {
-      return values;
-    }
-
-    JsonObject taskObject = graph.get(0).getAsObject();
-    JsonValue propertyValue = taskObject.get(propertyUri);
-    if (propertyValue == null) {
-      return values;
-    }
-
-    if (propertyValue.isArray()) {
-      propertyValue.getAsArray().forEach(value -> values.add(extractValue(value)));
-    } else {
-      values.add(extractValue(propertyValue));
-    }
-    return values;
-  }
-
-  private String extractValue(JsonValue value) {
-    if (value.isObject() && value.getAsObject().get("@value") != null) {
-      return value.getAsObject().get("@value").getAsString().value();
-    }
-    if (value.isObject() && value.getAsObject().get("@id") != null) {
-      return value.getAsObject().get("@id").getAsString().value();
-    }
-    if (value.isString()) {
-      return value.getAsString().value();
-    }
-    return value.toString();
+    return getPropertyValues(testTask.getGraphUri(), propertyUri);
   }
 }

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientTaskSettingsIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientTaskSettingsIT.java
@@ -1,0 +1,122 @@
+// Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
+package com.smartlogic.ontologyeditor;
+
+import com.smartlogic.ontologyeditor.beans.Label;
+import com.smartlogic.ontologyeditor.beans.Task;
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonArray;
+import org.apache.jena.atlas.json.JsonObject;
+import org.apache.jena.atlas.json.JsonValue;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Integration tests for updating task settings: label, comment, tags and permission roles.
+ */
+public class OEClientTaskSettingsIT extends AbstractModelScopedIT {
+
+  private Task testTask;
+
+  @Before
+  public void createTestTask() throws OEClientException {
+    if (oeClient == null) {
+      return;
+    }
+    String taskLabel = "IT task " + UUID.randomUUID();
+    testTask = oeClient.createTaskAndReturn(new Task(new Label("", taskLabel)));
+  }
+
+  @Test
+  public void updateTaskLabelReplacesDisplayName() throws OEClientException {
+    String newLabel = "IT task renamed " + UUID.randomUUID();
+    oeClient.updateTaskLabel(testTask, testTask.getLabel().getValue(), newLabel);
+    assertTrue(getTaskPropertyValues("rdfs:label").contains(newLabel));
+  }
+
+  @Test
+  public void updateTaskCommentAddsAndReplacesComment() throws OEClientException {
+    oeClient.updateTaskComment(testTask, null, "Initial description");
+    assertTrue(getTaskPropertyValues("rdfs:comment").contains("Initial description"));
+
+    oeClient.updateTaskComment(testTask, "Initial description", "Updated description");
+    List<String> comments = getTaskPropertyValues("rdfs:comment");
+    assertTrue(comments.contains("Updated description"));
+    assertFalse(comments.contains("Initial description"));
+  }
+
+  @Test
+  public void addAndRemoveTaskTag() throws OEClientException {
+    String tag = "IT tag " + UUID.randomUUID();
+
+    oeClient.addTaskTag(testTask, tag);
+    assertTrue(getTaskPropertyValues("sem:tag").contains(tag));
+
+    oeClient.removeTaskTag(testTask, tag);
+    assertFalse(getTaskPropertyValues("sem:tag").contains(tag));
+  }
+
+  @Test
+  public void assignAndUnassignTaskRole() throws OEClientException {
+    String principalUri = "role:SemaphoreUsers";
+
+    oeClient.assignTaskRole(testTask, "viewer", principalUri);
+    assertTrue(getTaskPropertyValues("sempermissions:viewer").contains(principalUri));
+
+    oeClient.unassignTaskRole(testTask, "viewer", principalUri);
+    assertFalse(getTaskPropertyValues("sempermissions:viewer").contains(principalUri));
+  }
+
+  /**
+   * Fetch the current values of a single property of the test task directly from the API.
+   */
+  private List<String> getTaskPropertyValues(String propertyUri) throws OEClientException {
+    Map<String, String> queryParameters = new HashMap<>();
+    queryParameters.put(OEClientReadOnly.PARAM_PROPERTIES, propertyUri);
+
+    String url = oeClient.getApiURL() + "sys/" + testTask.getGraphUri();
+    String response = oeClient.getResponse(url, queryParameters);
+
+    JsonObject jsonResponse = JSON.parse(response);
+    JsonArray graph = jsonResponse.get(OEClientReadOnly.JSON_LD_GRAPH).getAsArray();
+
+    List<String> values = new ArrayList<>();
+    if (graph.size() == 0) {
+      return values;
+    }
+
+    JsonObject taskObject = graph.get(0).getAsObject();
+    JsonValue propertyValue = taskObject.get(propertyUri);
+    if (propertyValue == null) {
+      return values;
+    }
+
+    if (propertyValue.isArray()) {
+      propertyValue.getAsArray().forEach(value -> values.add(extractValue(value)));
+    } else {
+      values.add(extractValue(propertyValue));
+    }
+    return values;
+  }
+
+  private String extractValue(JsonValue value) {
+    if (value.isObject() && value.getAsObject().get("@value") != null) {
+      return value.getAsObject().get("@value").getAsString().value();
+    }
+    if (value.isObject() && value.getAsObject().get("@id") != null) {
+      return value.getAsObject().get("@id").getAsString().value();
+    }
+    if (value.isString()) {
+      return value.getAsString().value();
+    }
+    return value.toString();
+  }
+}

--- a/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientTaskSettingsIT.java
+++ b/Semaphore-OE-Client/src/integration-test/java/com/smartlogic/ontologyeditor/OEClientTaskSettingsIT.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
 
 /**
  * Integration tests for updating task settings: label, comment, tags and permission roles.
@@ -40,6 +41,14 @@ public class OEClientTaskSettingsIT extends AbstractModelScopedIT {
     String newLabel = "IT task renamed " + UUID.randomUUID();
     oeClient.updateTaskLabel(testTask, testTask.getLabel().getValue(), newLabel);
     assertTrue(getTaskPropertyValues("rdfs:label").contains(newLabel));
+  }
+
+  @Test
+  public void getTaskReturnsCurrentDisplayName() throws OEClientException {
+    Task refetched = oeClient.getTask(testTask.getGraphUri());
+
+    assertEquals(testTask.getGraphUri(), refetched.getGraphUri());
+    assertEquals(testTask.getLabel().getValue(), refetched.getLabel().getValue());
   }
 
   @Test

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
@@ -421,6 +421,48 @@ public class OEClientReadOnly {
   }
 
   /**
+   * Get a single task's details by its graph URI.
+   *
+   * @param taskGraphUri the graph URI of the task to retrieve, e.g. {@code "task:fp1:myTask"}
+   * @return the task details
+   * @throws OEClientException - an error has occurred contacting the server
+   */
+  public Task getTask(String taskGraphUri) throws OEClientException {
+    logger.info("getTask entry: {}", taskGraphUri);
+
+    String url = getApiURL() + "sys/" + taskGraphUri;
+    logger.info("getTask URL: {}", url);
+    Map<String, String> queryParameters = new HashMap<>();
+    queryParameters.put(PARAM_PROPERTIES, "meta:displayName,meta:graphUri");
+
+    String response = getResponse(url, queryParameters);
+    JsonObject jsonResponse = JSON.parse(response);
+    JsonArray jsonArray = jsonResponse.get(JSON_LD_GRAPH).getAsArray();
+
+    if (jsonArray.size() == 0) {
+      throw new OEClientException("Task not found: " + taskGraphUri);
+    }
+
+    JsonObject taskObject = jsonArray.get(0).getAsObject();
+
+    JsonValue displayNameValue = taskObject.get("meta:displayName");
+    String labelValue =
+        (displayNameValue != null && displayNameValue.getAsObject().get("@value") != null)
+            ? displayNameValue.getAsObject().get("@value").getAsString().value()
+            : "";
+
+    JsonValue graphUriValue = taskObject.get("meta:graphUri");
+    String graphUri = (graphUriValue != null && graphUriValue.getAsObject().get("@id") != null)
+        ? graphUriValue.getAsObject().get("@id").getAsString().value()
+        : taskGraphUri;
+
+    JsonValue idValue = taskObject.get("@id");
+    String id = idValue != null ? idValue.getAsString().value() : null;
+
+    return new Task(new Label("", labelValue), id, graphUri);
+  }
+
+  /**
    * getAllTasks
    *
    * @return all the tasks present for this model

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadOnly.java
@@ -405,7 +405,8 @@ public class OEClientReadOnly {
     String url = getApiURL() + "sys/" + modelUri;
     logger.info("getModel URL: {}", url);
     Map<String, String> queryParameters = new HashMap<>();
-    queryParameters.put(PARAM_PROPERTIES, "meta:displayName,meta:graphUri,dcterms:language/[]");
+    queryParameters.put(PARAM_PROPERTIES,
+        "meta:displayName,meta:graphUri,dcterms:language/[],rdfs:comment,swa:defaultNamespace");
 
     String response = getResponse(url, queryParameters);
     JsonObject jsonResponse = JSON.parse(response);

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
@@ -75,6 +75,11 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	public String createModel(Model model) throws OEClientException {
 		logger.info("createModel entry: {}", model.getLabel());
 
+		if (model.getDefaultNamespace() == null || model.getDefaultNamespace().isBlank()) {
+			throw new OEClientException(
+					"A default namespace is required to create a model; call model.setDefaultNamespace(...) before createModel()");
+		}
+
 		String url = getApiURL() + "sys/sys:Model/rdf:instance";
 		logger.info("createModel URL: {}", url);
 

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
@@ -2598,12 +2598,277 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	}
 
 	/**
+	 * Update the comment (description) of a model.
+	 *
+	 * @param model the model to update
+	 * @param oldComment the existing comment to replace, or {@code null} if the model does not currently have a comment
+	 * @param newComment the new comment value
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void updateModelComment(Model model, String oldComment, String newComment) throws OEClientException {
+		logger.info("updateModelComment entry: {} {} {}", model.getUri(), oldComment, newComment);
+
+		JsonArray operationList = new JsonArray();
+
+		if (oldComment != null) {
+			JsonObject testOperation = new JsonObject();
+			testOperation.put("op", "test");
+			testOperation.put("path", "@graph/0/rdfs:comment/0");
+			JsonObject testValue = new JsonObject();
+			testValue.put("@value", oldComment);
+			testOperation.put("value", testValue);
+			operationList.add(testOperation);
+
+			JsonObject removeOperation = new JsonObject();
+			removeOperation.put("op", "remove");
+			removeOperation.put("path", "@graph/0/rdfs:comment/0");
+			operationList.add(removeOperation);
+		}
+
+		JsonObject addOperation = new JsonObject();
+		addOperation.put("op", "add");
+		addOperation.put("path", "@graph/0/rdfs:comment/-");
+		JsonObject newValueObject = new JsonObject();
+		newValueObject.put("@value", newComment);
+		addOperation.put("value", newValueObject);
+		operationList.add(addOperation);
+
+		String url = getApiURL() + "sys/" + model.getUri();
+		String payload = operationList.toString();
+		logger.info("updateModelComment payload: {}", payload);
+		makeRequest(url, payload, RequestType.PATCH);
+	}
+
+	/**
+	 * Update the default namespace of a model.
+	 *
+	 * @param model the model to update
+	 * @param oldDefaultNamespace the current default namespace to replace
+	 * @param newDefaultNamespace the new default namespace value
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void updateModelDefaultNamespace(Model model, String oldDefaultNamespace, String newDefaultNamespace) throws OEClientException {
+		logger.info("updateModelDefaultNamespace entry: {} {} {}", model.getUri(), oldDefaultNamespace, newDefaultNamespace);
+
+		JsonArray operationList = new JsonArray();
+
+		JsonObject testOperation = new JsonObject();
+		testOperation.put("op", "test");
+		testOperation.put("path", "@graph/0/swa:defaultNamespace/0");
+		JsonObject testValue = new JsonObject();
+		testValue.put("@value", oldDefaultNamespace);
+		testOperation.put("value", testValue);
+		operationList.add(testOperation);
+
+		JsonObject removeOperation = new JsonObject();
+		removeOperation.put("op", "remove");
+		removeOperation.put("path", "@graph/0/swa:defaultNamespace/0");
+		operationList.add(removeOperation);
+
+		JsonObject addOperation = new JsonObject();
+		addOperation.put("op", "add");
+		addOperation.put("path", "@graph/0/swa:defaultNamespace/-");
+		JsonObject newValueObject = new JsonObject();
+		newValueObject.put("@value", newDefaultNamespace);
+		addOperation.put("value", newValueObject);
+		operationList.add(addOperation);
+
+		String url = getApiURL() + "sys/" + model.getUri();
+		String payload = operationList.toString();
+		logger.info("updateModelDefaultNamespace payload: {}", payload);
+		makeRequest(url, payload, RequestType.PATCH);
+	}
+
+	/**
+	 * Update the color of a model.
+	 *
+	 * @param model the model to update
+	 * @param oldColorHex the current color, as a hex string (e.g. {@code "00c851"}), or {@code null} if the model does not currently have a color
+	 * @param newColorHex the new color, as a hex string (e.g. {@code "7fa38e"})
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void updateModelColor(Model model, String oldColorHex, String newColorHex) throws OEClientException {
+		logger.info("updateModelColor entry: {} {} {}", model.getUri(), oldColorHex, newColorHex);
+
+		JsonArray operationList = new JsonArray();
+
+		if (oldColorHex != null) {
+			JsonObject testOperation = new JsonObject();
+			testOperation.put("op", "test");
+			testOperation.put("path", "@graph/0/sem:color/0");
+			JsonObject testValue = new JsonObject();
+			testValue.put("@type", "xsd:hexBinary");
+			testValue.put("@value", oldColorHex);
+			testOperation.put("value", testValue);
+			operationList.add(testOperation);
+
+			JsonObject removeOperation = new JsonObject();
+			removeOperation.put("op", "remove");
+			removeOperation.put("path", "@graph/0/sem:color/0");
+			operationList.add(removeOperation);
+		}
+
+		JsonObject addOperation = new JsonObject();
+		addOperation.put("op", "add");
+		addOperation.put("path", "@graph/0/sem:color/-");
+		JsonObject newValueObject = new JsonObject();
+		newValueObject.put("@type", "xsd:hexBinary");
+		newValueObject.put("@value", newColorHex);
+		addOperation.put("value", newValueObject);
+		operationList.add(addOperation);
+
+		String url = getApiURL() + "sys/" + model.getUri();
+		String payload = operationList.toString();
+		logger.info("updateModelColor payload: {}", payload);
+		makeRequest(url, payload, RequestType.PATCH);
+	}
+
+	/**
+	 * Add a tag to a model.
+	 *
+	 * @param model the model to update
+	 * @param tag the tag to add
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void addModelTag(Model model, String tag) throws OEClientException {
+		logger.info("addModelTag entry: {} {}", model.getUri(), tag);
+
+		JsonArray operationList = new JsonArray();
+
+		JsonObject addOperation = new JsonObject();
+		addOperation.put("op", "add");
+		addOperation.put("path", "@graph/0/sem:tag/-");
+		JsonObject newValueObject = new JsonObject();
+		newValueObject.put("@value", tag);
+		addOperation.put("value", newValueObject);
+		operationList.add(addOperation);
+
+		String url = getApiURL() + "sys/" + model.getUri();
+		String payload = operationList.toString();
+		logger.info("addModelTag payload: {}", payload);
+		makeRequest(url, payload, RequestType.PATCH);
+	}
+
+	/**
+	 * Remove a tag from a model.
+	 *
+	 * @param model the model to update
+	 * @param tag the tag to remove
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void removeModelTag(Model model, String tag) throws OEClientException {
+		logger.info("removeModelTag entry: {} {}", model.getUri(), tag);
+
+		JsonArray operationList = new JsonArray();
+
+		JsonObject testOperation = new JsonObject();
+		testOperation.put("op", "test");
+		testOperation.put("path", "@graph/0/sem:tag/0");
+		JsonObject testValue = new JsonObject();
+		testValue.put("@value", tag);
+		testOperation.put("value", testValue);
+		operationList.add(testOperation);
+
+		JsonObject removeOperation = new JsonObject();
+		removeOperation.put("op", "remove");
+		removeOperation.put("path", "@graph/0/sem:tag/0");
+		operationList.add(removeOperation);
+
+		String url = getApiURL() + "sys/" + model.getUri();
+		String payload = operationList.toString();
+		logger.info("removeModelTag payload: {}", payload);
+		makeRequest(url, payload, RequestType.PATCH);
+	}
+
+	private static final Set<String> MODEL_ROLES = Set.of("manager", "editor", "viewer");
+
+	/**
+	 * Assign a user (or Semaphore role, e.g. {@code role:SemaphoreUsers}) to a model permission
+	 * role. Corresponds to the {@code sempermissions:manager}, {@code sempermissions:editor}, and
+	 * {@code sempermissions:viewer} predicates.
+	 *
+	 * @param model the model to update
+	 * @param role the permission role to assign the principal to; one of {@code manager},
+	 *        {@code editor}, or {@code viewer}
+	 * @param principalUri the URI of the user (e.g. {@code user:jsmith}) or role (e.g.
+	 *        {@code role:SemaphoreAdministrators}) to assign
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
+	 *         not a recognized model permission role
+	 */
+	public void assignModelRole(Model model, String role, String principalUri) throws OEClientException {
+		logger.info("assignModelRole entry: {} {} {}", model.getUri(), role, principalUri);
+
+		String normalizedRole = validateModelRole(role);
+
+		JsonArray operationList = new JsonArray();
+
+		JsonObject addOperation = new JsonObject();
+		addOperation.put("op", "add");
+		addOperation.put("path", "@graph/0/sempermissions:" + normalizedRole + "/-");
+		JsonObject valueObject = new JsonObject();
+		valueObject.put("@id", principalUri);
+		addOperation.put("value", valueObject);
+		operationList.add(addOperation);
+
+		String url = getApiURL() + "sys/" + model.getUri();
+		String payload = operationList.toString();
+		logger.info("assignModelRole payload: {}", payload);
+		makeRequest(url, payload, RequestType.PATCH);
+	}
+
+	/**
+	 * Remove a user (or Semaphore role) from a model permission role.
+	 *
+	 * @param model the model to update
+	 * @param role the permission role to remove the principal from; one of {@code manager},
+	 *        {@code editor}, or {@code viewer}
+	 * @param principalUri the URI of the user or role to remove (e.g. {@code user:jsmith})
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
+	 *         not a recognized model permission role
+	 */
+	public void unassignModelRole(Model model, String role, String principalUri) throws OEClientException {
+		logger.info("unassignModelRole entry: {} {} {}", model.getUri(), role, principalUri);
+
+		String normalizedRole = validateModelRole(role);
+
+		JsonArray operationList = new JsonArray();
+
+		JsonObject testOperation = new JsonObject();
+		testOperation.put("op", "test");
+		testOperation.put("path", "@graph/0/sempermissions:" + normalizedRole + "/0");
+		JsonObject testValue = new JsonObject();
+		testValue.put("@id", principalUri);
+		testOperation.put("value", testValue);
+		operationList.add(testOperation);
+
+		JsonObject removeOperation = new JsonObject();
+		removeOperation.put("op", "remove");
+		removeOperation.put("path", "@graph/0/sempermissions:" + normalizedRole + "/0");
+		operationList.add(removeOperation);
+
+		String url = getApiURL() + "sys/" + model.getUri();
+		String payload = operationList.toString();
+		logger.info("unassignModelRole payload: {}", payload);
+		makeRequest(url, payload, RequestType.PATCH);
+	}
+
+	private String validateModelRole(String role) throws OEClientException {
+		String normalizedRole = role == null ? "" : role.trim().toLowerCase();
+		if (!MODEL_ROLES.contains(normalizedRole)) {
+			throw new OEClientException(
+					"Invalid model role: " + role + ". Must be one of: manager, editor, viewer");
+		}
+		return normalizedRole;
+	}
+
+	/**
 	 * Checks if the client is in KRT mode, and if so, add the concept to the Modified KRT concept scheme.
 	 * @param operationList the JSON PATCH operation list object
 	 * @param conceptIndex the JSON PATCH index of the concept.
 	 * @throws OEClientException exception
 	 */
 	protected void checkKRTModified(JsonArray operationList, String conceptIndex) throws OEClientException {
+
 
 		if (conceptIndex != null && !isDigits(conceptIndex)) throw new OEClientException("Invalid concept index: " + conceptIndex);
 

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
@@ -77,7 +77,8 @@ public class OEClientReadWrite extends OEClientReadOnly {
 
 		if (model.getDefaultNamespace() == null || model.getDefaultNamespace().isBlank()) {
 			throw new OEClientException(
-					"A default namespace is required to create a model; call model.setDefaultNamespace(...) before createModel()");
+					"A default namespace is required to create a model; call model.setDefaultNamespace(...) "
+							+ "or use the Model(uri, label, comment, defaultNamespace) constructor before createModel()");
 		}
 
 		String url = getApiURL() + "sys/sys:Model/rdf:instance";
@@ -2771,18 +2772,20 @@ public class OEClientReadWrite extends OEClientReadOnly {
 
 		JsonArray operationList = new JsonArray();
 
-		JsonObject testOperation = new JsonObject();
-		testOperation.put("op", "test");
-		testOperation.put("path", "@graph/0/swa:defaultNamespace/0");
-		JsonObject testValue = new JsonObject();
-		testValue.put("@value", oldDefaultNamespace);
-		testOperation.put("value", testValue);
-		operationList.add(testOperation);
+		if (oldDefaultNamespace != null) {
+			JsonObject testOperation = new JsonObject();
+			testOperation.put("op", "test");
+			testOperation.put("path", "@graph/0/swa:defaultNamespace/0");
+			JsonObject testValue = new JsonObject();
+			testValue.put("@value", oldDefaultNamespace);
+			testOperation.put("value", testValue);
+			operationList.add(testOperation);
 
-		JsonObject removeOperation = new JsonObject();
-		removeOperation.put("op", "remove");
-		removeOperation.put("path", "@graph/0/swa:defaultNamespace/0");
-		operationList.add(removeOperation);
+			JsonObject removeOperation = new JsonObject();
+			removeOperation.put("op", "remove");
+			removeOperation.put("path", "@graph/0/swa:defaultNamespace/0");
+			operationList.add(removeOperation);
+		}
 
 		JsonObject addOperation = new JsonObject();
 		addOperation.put("op", "add");
@@ -2871,9 +2874,14 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 *
 	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
 	 * @param tag the tag to add
-	 * @throws OEClientException - an error has occurred contacting the server
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code tag} is
+	 *         null or blank
 	 */
 	private void addTag(String sysUrl, String tag) throws OEClientException {
+		if (tag == null || tag.isBlank()) {
+			throw new OEClientException("tag must not be null or blank");
+		}
+
 		JsonArray operationList = new JsonArray();
 
 		JsonObject addOperation = new JsonObject();
@@ -2918,9 +2926,14 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 *
 	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
 	 * @param tag the tag to remove
-	 * @throws OEClientException - an error has occurred contacting the server
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code tag} is
+	 *         null or blank
 	 */
 	private void removeTag(String sysUrl, String tag) throws OEClientException {
+		if (tag == null || tag.isBlank()) {
+			throw new OEClientException("tag must not be null or blank");
+		}
+
 		JsonArray operationList = new JsonArray();
 
 		JsonObject testOperation = new JsonObject();
@@ -2986,11 +2999,14 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 * @param role the permission role to assign the principal to; one of {@code manager},
 	 *        {@code editor}, or {@code viewer}
 	 * @param principalUri the URI of the user or role to assign
-	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
-	 *         not a recognized permission role
+	 * @throws OEClientException - an error has occurred contacting the server, {@code role} is
+	 *         not a recognized permission role, or {@code principalUri} is null or blank
 	 */
 	private void assignRole(String sysUrl, String role, String principalUri) throws OEClientException {
 		String normalizedRole = validatePermissionRole(role);
+		if (principalUri == null || principalUri.isBlank()) {
+			throw new OEClientException("principalUri must not be null or blank");
+		}
 
 		JsonArray operationList = new JsonArray();
 
@@ -3045,11 +3061,14 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 * @param role the permission role to remove the principal from; one of {@code manager},
 	 *        {@code editor}, or {@code viewer}
 	 * @param principalUri the URI of the user or role to remove
-	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
-	 *         not a recognized permission role
+	 * @throws OEClientException - an error has occurred contacting the server, {@code role} is
+	 *         not a recognized permission role, or {@code principalUri} is null or blank
 	 */
 	private void unassignRole(String sysUrl, String role, String principalUri) throws OEClientException {
 		String normalizedRole = validatePermissionRole(role);
+		if (principalUri == null || principalUri.isBlank()) {
+			throw new OEClientException("principalUri must not be null or blank");
+		}
 
 		JsonArray operationList = new JsonArray();
 

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
@@ -2567,14 +2567,38 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 */
 	public void updateModel(Model model, String newDisplayName) throws OEClientException {
 		logger.info("updateModel entry: {} {}", model.getUri(), newDisplayName);
+		updateLabel(getApiURL() + "sys/" + model.getUri(), model.getLabel().getValue(), newDisplayName);
+	}
 
+	/**
+	 * Update the display name (rdfs:label) of a task.
+	 *
+	 * @param task the task to update
+	 * @param oldDisplayName the task's current display name
+	 * @param newDisplayName the new display name
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void updateTaskLabel(Task task, String oldDisplayName, String newDisplayName) throws OEClientException {
+		logger.info("updateTaskLabel entry: {} {} {}", task.getGraphUri(), oldDisplayName, newDisplayName);
+		updateLabel(getTaskSysURL(task), oldDisplayName, newDisplayName);
+	}
+
+	/**
+	 * Replace the rdfs:label of the resource at {@code sysUrl}.
+	 *
+	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
+	 * @param oldLabel the resource's current display name
+	 * @param newLabel the new display name
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	private void updateLabel(String sysUrl, String oldLabel, String newLabel) throws OEClientException {
 		JsonArray operationList = new JsonArray();
 
 		JsonObject testOperation = new JsonObject();
 		testOperation.put("op", "test");
 		testOperation.put("path", "@graph/0/rdfs:label/0");
 		JsonObject testValue = new JsonObject();
-		testValue.put("@value", model.getLabel().getValue());
+		testValue.put("@value", oldLabel);
 		testOperation.put("value", testValue);
 		operationList.add(testOperation);
 
@@ -2587,14 +2611,13 @@ public class OEClientReadWrite extends OEClientReadOnly {
 		addOperation.put("op", "add");
 		addOperation.put("path", "@graph/0/rdfs:label/-");
 		JsonObject newValueObject = new JsonObject();
-		newValueObject.put("@value", newDisplayName);
+		newValueObject.put("@value", newLabel);
 		addOperation.put("value", newValueObject);
 		operationList.add(addOperation);
 
-		String url = getApiURL() + "sys/" + model.getUri();
 		String payload = operationList.toString();
-		logger.info("updateModel payload: {}", payload);
-		makeRequest(url, payload, RequestType.PATCH);
+		logger.info("updateLabel payload: {}", payload);
+		makeRequest(sysUrl, payload, RequestType.PATCH);
 	}
 
 	/**
@@ -2607,7 +2630,31 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 */
 	public void updateModelComment(Model model, String oldComment, String newComment) throws OEClientException {
 		logger.info("updateModelComment entry: {} {} {}", model.getUri(), oldComment, newComment);
+		updateComment(getApiURL() + "sys/" + model.getUri(), oldComment, newComment);
+	}
 
+	/**
+	 * Update the comment (description) of a task.
+	 *
+	 * @param task the task to update
+	 * @param oldComment the existing comment to replace, or {@code null} if the task does not currently have a comment
+	 * @param newComment the new comment value
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void updateTaskComment(Task task, String oldComment, String newComment) throws OEClientException {
+		logger.info("updateTaskComment entry: {} {} {}", task.getGraphUri(), oldComment, newComment);
+		updateComment(getTaskSysURL(task), oldComment, newComment);
+	}
+
+	/**
+	 * Replace the rdfs:comment of the resource at {@code sysUrl}.
+	 *
+	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
+	 * @param oldComment the resource's current comment, or {@code null} if it doesn't have one yet
+	 * @param newComment the new comment value
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	private void updateComment(String sysUrl, String oldComment, String newComment) throws OEClientException {
 		JsonArray operationList = new JsonArray();
 
 		if (oldComment != null) {
@@ -2633,10 +2680,9 @@ public class OEClientReadWrite extends OEClientReadOnly {
 		addOperation.put("value", newValueObject);
 		operationList.add(addOperation);
 
-		String url = getApiURL() + "sys/" + model.getUri();
 		String payload = operationList.toString();
-		logger.info("updateModelComment payload: {}", payload);
-		makeRequest(url, payload, RequestType.PATCH);
+		logger.info("updateComment payload: {}", payload);
+		makeRequest(sysUrl, payload, RequestType.PATCH);
 	}
 
 	/**
@@ -2732,7 +2778,29 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 */
 	public void addModelTag(Model model, String tag) throws OEClientException {
 		logger.info("addModelTag entry: {} {}", model.getUri(), tag);
+		addTag(getApiURL() + "sys/" + model.getUri(), tag);
+	}
 
+	/**
+	 * Add a tag to a task.
+	 *
+	 * @param task the task to update
+	 * @param tag the tag to add
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void addTaskTag(Task task, String tag) throws OEClientException {
+		logger.info("addTaskTag entry: {} {}", task.getGraphUri(), tag);
+		addTag(getTaskSysURL(task), tag);
+	}
+
+	/**
+	 * Add a sem:tag value to the resource at {@code sysUrl}.
+	 *
+	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
+	 * @param tag the tag to add
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	private void addTag(String sysUrl, String tag) throws OEClientException {
 		JsonArray operationList = new JsonArray();
 
 		JsonObject addOperation = new JsonObject();
@@ -2743,10 +2811,9 @@ public class OEClientReadWrite extends OEClientReadOnly {
 		addOperation.put("value", newValueObject);
 		operationList.add(addOperation);
 
-		String url = getApiURL() + "sys/" + model.getUri();
 		String payload = operationList.toString();
-		logger.info("addModelTag payload: {}", payload);
-		makeRequest(url, payload, RequestType.PATCH);
+		logger.info("addTag payload: {}", payload);
+		makeRequest(sysUrl, payload, RequestType.PATCH);
 	}
 
 	/**
@@ -2758,7 +2825,29 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 */
 	public void removeModelTag(Model model, String tag) throws OEClientException {
 		logger.info("removeModelTag entry: {} {}", model.getUri(), tag);
+		removeTag(getApiURL() + "sys/" + model.getUri(), tag);
+	}
 
+	/**
+	 * Remove a tag from a task.
+	 *
+	 * @param task the task to update
+	 * @param tag the tag to remove
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	public void removeTaskTag(Task task, String tag) throws OEClientException {
+		logger.info("removeTaskTag entry: {} {}", task.getGraphUri(), tag);
+		removeTag(getTaskSysURL(task), tag);
+	}
+
+	/**
+	 * Remove a sem:tag value from the resource at {@code sysUrl}.
+	 *
+	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
+	 * @param tag the tag to remove
+	 * @throws OEClientException - an error has occurred contacting the server
+	 */
+	private void removeTag(String sysUrl, String tag) throws OEClientException {
 		JsonArray operationList = new JsonArray();
 
 		JsonObject testOperation = new JsonObject();
@@ -2774,13 +2863,12 @@ public class OEClientReadWrite extends OEClientReadOnly {
 		removeOperation.put("path", "@graph/0/sem:tag/0");
 		operationList.add(removeOperation);
 
-		String url = getApiURL() + "sys/" + model.getUri();
 		String payload = operationList.toString();
-		logger.info("removeModelTag payload: {}", payload);
-		makeRequest(url, payload, RequestType.PATCH);
+		logger.info("removeTag payload: {}", payload);
+		makeRequest(sysUrl, payload, RequestType.PATCH);
 	}
 
-	private static final Set<String> MODEL_ROLES = Set.of("manager", "editor", "viewer");
+	private static final Set<String> PERMISSION_ROLES = Set.of("manager", "editor", "viewer");
 
 	/**
 	 * Assign a user (or Semaphore role, e.g. {@code role:SemaphoreUsers}) to a model permission
@@ -2793,12 +2881,43 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 * @param principalUri the URI of the user (e.g. {@code user:jsmith}) or role (e.g.
 	 *        {@code role:SemaphoreAdministrators}) to assign
 	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
-	 *         not a recognized model permission role
+	 *         not a recognized permission role
 	 */
 	public void assignModelRole(Model model, String role, String principalUri) throws OEClientException {
 		logger.info("assignModelRole entry: {} {} {}", model.getUri(), role, principalUri);
+		assignRole(getApiURL() + "sys/" + model.getUri(), role, principalUri);
+	}
 
-		String normalizedRole = validateModelRole(role);
+	/**
+	 * Assign a user (or Semaphore role) to a task permission role. Corresponds to the same
+	 * {@code sempermissions:manager}/{@code editor}/{@code viewer} predicates used for models.
+	 *
+	 * @param task the task to update
+	 * @param role the permission role to assign the principal to; one of {@code manager},
+	 *        {@code editor}, or {@code viewer}
+	 * @param principalUri the URI of the user (e.g. {@code user:jsmith}) or role (e.g.
+	 *        {@code role:SemaphoreAdministrators}) to assign
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
+	 *         not a recognized permission role
+	 */
+	public void assignTaskRole(Task task, String role, String principalUri) throws OEClientException {
+		logger.info("assignTaskRole entry: {} {} {}", task.getGraphUri(), role, principalUri);
+		assignRole(getTaskSysURL(task), role, principalUri);
+	}
+
+	/**
+	 * Add a principal to a {@code sempermissions:{role}} predicate on the resource at
+	 * {@code sysUrl}.
+	 *
+	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
+	 * @param role the permission role to assign the principal to; one of {@code manager},
+	 *        {@code editor}, or {@code viewer}
+	 * @param principalUri the URI of the user or role to assign
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
+	 *         not a recognized permission role
+	 */
+	private void assignRole(String sysUrl, String role, String principalUri) throws OEClientException {
+		String normalizedRole = validatePermissionRole(role);
 
 		JsonArray operationList = new JsonArray();
 
@@ -2810,10 +2929,9 @@ public class OEClientReadWrite extends OEClientReadOnly {
 		addOperation.put("value", valueObject);
 		operationList.add(addOperation);
 
-		String url = getApiURL() + "sys/" + model.getUri();
 		String payload = operationList.toString();
-		logger.info("assignModelRole payload: {}", payload);
-		makeRequest(url, payload, RequestType.PATCH);
+		logger.info("assignRole payload: {}", payload);
+		makeRequest(sysUrl, payload, RequestType.PATCH);
 	}
 
 	/**
@@ -2824,12 +2942,41 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 *        {@code editor}, or {@code viewer}
 	 * @param principalUri the URI of the user or role to remove (e.g. {@code user:jsmith})
 	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
-	 *         not a recognized model permission role
+	 *         not a recognized permission role
 	 */
 	public void unassignModelRole(Model model, String role, String principalUri) throws OEClientException {
 		logger.info("unassignModelRole entry: {} {} {}", model.getUri(), role, principalUri);
+		unassignRole(getApiURL() + "sys/" + model.getUri(), role, principalUri);
+	}
 
-		String normalizedRole = validateModelRole(role);
+	/**
+	 * Remove a user (or Semaphore role) from a task permission role.
+	 *
+	 * @param task the task to update
+	 * @param role the permission role to remove the principal from; one of {@code manager},
+	 *        {@code editor}, or {@code viewer}
+	 * @param principalUri the URI of the user or role to remove (e.g. {@code user:jsmith})
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
+	 *         not a recognized permission role
+	 */
+	public void unassignTaskRole(Task task, String role, String principalUri) throws OEClientException {
+		logger.info("unassignTaskRole entry: {} {} {}", task.getGraphUri(), role, principalUri);
+		unassignRole(getTaskSysURL(task), role, principalUri);
+	}
+
+	/**
+	 * Remove a principal from a {@code sempermissions:{role}} predicate on the resource at
+	 * {@code sysUrl}.
+	 *
+	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
+	 * @param role the permission role to remove the principal from; one of {@code manager},
+	 *        {@code editor}, or {@code viewer}
+	 * @param principalUri the URI of the user or role to remove
+	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
+	 *         not a recognized permission role
+	 */
+	private void unassignRole(String sysUrl, String role, String principalUri) throws OEClientException {
+		String normalizedRole = validatePermissionRole(role);
 
 		JsonArray operationList = new JsonArray();
 
@@ -2846,17 +2993,16 @@ public class OEClientReadWrite extends OEClientReadOnly {
 		removeOperation.put("path", "@graph/0/sempermissions:" + normalizedRole + "/0");
 		operationList.add(removeOperation);
 
-		String url = getApiURL() + "sys/" + model.getUri();
 		String payload = operationList.toString();
-		logger.info("unassignModelRole payload: {}", payload);
-		makeRequest(url, payload, RequestType.PATCH);
+		logger.info("unassignRole payload: {}", payload);
+		makeRequest(sysUrl, payload, RequestType.PATCH);
 	}
 
-	private String validateModelRole(String role) throws OEClientException {
+	private String validatePermissionRole(String role) throws OEClientException {
 		String normalizedRole = role == null ? "" : role.trim().toLowerCase();
-		if (!MODEL_ROLES.contains(normalizedRole)) {
+		if (!PERMISSION_ROLES.contains(normalizedRole)) {
 			throw new OEClientException(
-					"Invalid model role: " + role + ". Must be one of: manager, editor, viewer");
+					"Invalid permission role: " + role + ". Must be one of: manager, editor, viewer");
 		}
 		return normalizedRole;
 	}

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/OEClientReadWrite.java
@@ -2954,16 +2954,19 @@ public class OEClientReadWrite extends OEClientReadOnly {
 		makeRequest(sysUrl, payload, RequestType.PATCH);
 	}
 
-	private static final Set<String> PERMISSION_ROLES = Set.of("manager", "editor", "viewer");
+	private static final Set<String> PERMISSION_ROLES =
+			Set.of("manager", "editor", "contributor", "viewer");
 
 	/**
 	 * Assign a user (or Semaphore role, e.g. {@code role:SemaphoreUsers}) to a model permission
-	 * role. Corresponds to the {@code sempermissions:manager}, {@code sempermissions:editor}, and
-	 * {@code sempermissions:viewer} predicates.
+	 * role. Corresponds to the {@code sempermissions:manager}, {@code sempermissions:editor},
+	 * {@code sempermissions:contributor}, and {@code sempermissions:viewer} predicates. Roles are
+	 * hierarchical, from most to least privileged: manager, editor, contributor, viewer (labelled
+	 * "Reviewer" in the KMM UI).
 	 *
 	 * @param model the model to update
 	 * @param role the permission role to assign the principal to; one of {@code manager},
-	 *        {@code editor}, or {@code viewer}
+	 *        {@code editor}, {@code contributor}, or {@code viewer}
 	 * @param principalUri the URI of the user (e.g. {@code user:jsmith}) or role (e.g.
 	 *        {@code role:SemaphoreAdministrators}) to assign
 	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
@@ -2976,11 +2979,12 @@ public class OEClientReadWrite extends OEClientReadOnly {
 
 	/**
 	 * Assign a user (or Semaphore role) to a task permission role. Corresponds to the same
-	 * {@code sempermissions:manager}/{@code editor}/{@code viewer} predicates used for models.
+	 * {@code sempermissions:manager}/{@code editor}/{@code contributor}/{@code viewer} predicates
+	 * used for models.
 	 *
 	 * @param task the task to update
 	 * @param role the permission role to assign the principal to; one of {@code manager},
-	 *        {@code editor}, or {@code viewer}
+	 *        {@code editor}, {@code contributor}, or {@code viewer}
 	 * @param principalUri the URI of the user (e.g. {@code user:jsmith}) or role (e.g.
 	 *        {@code role:SemaphoreAdministrators}) to assign
 	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
@@ -2997,7 +3001,7 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 *
 	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
 	 * @param role the permission role to assign the principal to; one of {@code manager},
-	 *        {@code editor}, or {@code viewer}
+	 *        {@code editor}, {@code contributor}, or {@code viewer}
 	 * @param principalUri the URI of the user or role to assign
 	 * @throws OEClientException - an error has occurred contacting the server, {@code role} is
 	 *         not a recognized permission role, or {@code principalUri} is null or blank
@@ -3028,7 +3032,7 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 *
 	 * @param model the model to update
 	 * @param role the permission role to remove the principal from; one of {@code manager},
-	 *        {@code editor}, or {@code viewer}
+	 *        {@code editor}, {@code contributor}, or {@code viewer}
 	 * @param principalUri the URI of the user or role to remove (e.g. {@code user:jsmith})
 	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
 	 *         not a recognized permission role
@@ -3043,7 +3047,7 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 *
 	 * @param task the task to update
 	 * @param role the permission role to remove the principal from; one of {@code manager},
-	 *        {@code editor}, or {@code viewer}
+	 *        {@code editor}, {@code contributor}, or {@code viewer}
 	 * @param principalUri the URI of the user or role to remove (e.g. {@code user:jsmith})
 	 * @throws OEClientException - an error has occurred contacting the server, or {@code role} is
 	 *         not a recognized permission role
@@ -3059,7 +3063,7 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	 *
 	 * @param sysUrl the {@code sys/} resource URL of the model or task to update
 	 * @param role the permission role to remove the principal from; one of {@code manager},
-	 *        {@code editor}, or {@code viewer}
+	 *        {@code editor}, {@code contributor}, or {@code viewer}
 	 * @param principalUri the URI of the user or role to remove
 	 * @throws OEClientException - an error has occurred contacting the server, {@code role} is
 	 *         not a recognized permission role, or {@code principalUri} is null or blank
@@ -3093,8 +3097,8 @@ public class OEClientReadWrite extends OEClientReadOnly {
 	private String validatePermissionRole(String role) throws OEClientException {
 		String normalizedRole = role == null ? "" : role.trim().toLowerCase();
 		if (!PERMISSION_ROLES.contains(normalizedRole)) {
-			throw new OEClientException(
-					"Invalid permission role: " + role + ". Must be one of: manager, editor, viewer");
+			throw new OEClientException("Invalid permission role: " + role +
+					". Must be one of: manager, editor, contributor, viewer");
 		}
 		return normalizedRole;
 	}

--- a/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/beans/Model.java
+++ b/Semaphore-OE-Client/src/main/java/com/smartlogic/ontologyeditor/beans/Model.java
@@ -9,7 +9,7 @@ import java.util.List;
 
 public class Model {
 
-	String defaultNamespace = "http://example.org/api-test#";
+	String defaultNamespace;
 	public Model(JsonObject jsonObject) {
 		JsonValue displayNameValue = jsonObject.get("meta:displayName");
 		if (displayNameValue != null) {
@@ -23,7 +23,11 @@ public class Model {
 			label = new Label("", "No display name found");
 		}
 		uri = jsonObject.get("meta:graphUri").getAsObject().get("@id").getAsString().value();
-		comment = null;
+		comment = extractFirstStringValue(jsonObject, "rdfs:comment");
+		String parsedDefaultNamespace = extractFirstStringValue(jsonObject, "swa:defaultNamespace");
+		if (parsedDefaultNamespace != null) {
+			defaultNamespace = parsedDefaultNamespace;
+		}
 		languages = new ArrayList<>();
 		JsonValue languagesValue = jsonObject.get("dcterms:language");
 		if (languagesValue != null) {
@@ -31,10 +35,56 @@ public class Model {
 		}
 	}
 
+	/**
+	 * Extracts the first plain string value of a (possibly single- or multi-valued) JSON-LD
+	 * property, e.g. {@code {"@value": "..."}} or {@code {"@id": "..."}}, or an array of such
+	 * objects. Returns {@code null} if the property is absent, empty, or has neither an
+	 * {@code @value} nor an {@code @id}.
+	 */
+	private static String extractFirstStringValue(JsonObject jsonObject, String propertyUri) {
+		JsonValue propertyValue = jsonObject.get(propertyUri);
+		if (propertyValue == null) {
+			return null;
+		}
+		JsonValue firstValue = propertyValue;
+		if (propertyValue.isArray()) {
+			if (propertyValue.getAsArray().size() == 0) {
+				return null;
+			}
+			firstValue = propertyValue.getAsArray().get(0);
+		}
+		if (firstValue.isObject() && firstValue.getAsObject().get("@value") != null) {
+			return firstValue.getAsObject().get("@value").getAsString().value();
+		}
+		if (firstValue.isObject() && firstValue.getAsObject().get("@id") != null) {
+			return firstValue.getAsObject().get("@id").getAsString().value();
+		}
+		if (firstValue.isString()) {
+			return firstValue.getAsString().value();
+		}
+		return null;
+	}
+
 	public Model(String uri, Label label, String comment) {
 		this(uri, label, comment, new ArrayList<>());
 	}
-	
+
+	/**
+	 * Create a model with explicit URI, label, comment, and default namespace. Use this
+	 * constructor (rather than {@link #Model(String, Label, String)}) when the model is going
+	 * to be passed to {@link com.smartlogic.ontologyeditor.OEClientReadWrite#createModel(Model)},
+	 * which requires a non-blank default namespace.
+	 *
+	 * @param uri the model URI
+	 * @param label the model display label
+	 * @param comment the model comment
+	 * @param defaultNamespace the model's default namespace, e.g. {@code "http://example.com/my-model#"}
+	 */
+	public Model(String uri, Label label, String comment, String defaultNamespace) {
+		this(uri, label, comment, new ArrayList<>());
+		this.defaultNamespace = defaultNamespace;
+	}
+
 	/**
 	 * Create a model with explicit URI, label, comment, and languages.
 	 *

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadOnlyTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadOnlyTest.java
@@ -2,6 +2,7 @@
 package com.smartlogic.ontologyeditor;
 
 import com.smartlogic.ontologyeditor.beans.Model;
+import com.smartlogic.ontologyeditor.beans.Task;
 import org.junit.Test;
 
 import java.net.URI;
@@ -72,6 +73,31 @@ public class OEClientReadOnlyTest {
       fail("Expected OEClientException for missing model");
     } catch (OEClientException ex) {
       assertTrue(ex.getMessage().contains("Model not found: missing:model"));
+    }
+  }
+
+  @Test
+  public void getTaskReturnsMappedTaskWhenPresent() throws OEClientException {
+    StubReadOnlyClient client = newClient();
+    client.enqueueResponse("{\"@graph\":[{\"@id\":\"task:1\",\"meta:displayName\":{\"@value\":\"My Task\"},\"meta:graphUri\":{\"@id\":\"task:fp1:myTask\"}}]}");
+
+    Task task = client.getTask("task:fp1:myTask");
+
+    assertEquals("task:fp1:myTask", task.getGraphUri());
+    assertEquals("My Task", task.getLabel().getValue());
+    assertEquals("task:1", task.getId());
+  }
+
+  @Test
+  public void getTaskThrowsWhenGraphEmpty() throws OEClientException {
+    StubReadOnlyClient client = newClient();
+    client.enqueueResponse("{\"@graph\":[]}");
+
+    try {
+      client.getTask("missing:task");
+      fail("Expected OEClientException for missing task");
+    } catch (OEClientException ex) {
+      assertTrue(ex.getMessage().contains("Task not found: missing:task"));
     }
   }
 

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
@@ -448,6 +448,78 @@ public class OEClientReadWriteTest {
   }
 
   @Test
+  public void assignModelRolePayloadAddsPrincipalByReference() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    client.assignModelRole(model, "manager", "user:jsmith");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    com.google.gson.JsonObject addOp = patch.get(0).getAsJsonObject();
+    assertEquals("add", addOp.get("op").getAsString());
+    assertEquals("@graph/0/sempermissions:manager/-", addOp.get("path").getAsString());
+    assertEquals("user:jsmith", addOp.getAsJsonObject("value").get("@id").getAsString());
+  }
+
+  @Test
+  public void assignModelRoleNormalizesRoleCase() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    client.assignModelRole(model, "Editor", "role:SemaphoreUsers");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    assertEquals("@graph/0/sempermissions:editor/-",
+        patch.get(0).getAsJsonObject().get("path").getAsString());
+  }
+
+  @Test
+  public void assignModelRoleRejectsUnknownRole() {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    try {
+      client.assignModelRole(model, "owner", "user:jsmith");
+      fail("Expected OEClientException for unknown role");
+    } catch (OEClientException e) {
+      assertTrue(e.getMessage().contains("owner"));
+    }
+    assertEquals(0, client.makeRequestCallCount);
+  }
+
+  @Test
+  public void unassignModelRolePayloadTestsAndRemovesPrincipal() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    client.unassignModelRole(model, "viewer", "user:jsmith");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    com.google.gson.JsonObject testOp = patch.get(0).getAsJsonObject();
+    assertEquals("test", testOp.get("op").getAsString());
+    assertEquals("@graph/0/sempermissions:viewer/0", testOp.get("path").getAsString());
+    assertEquals("user:jsmith", testOp.getAsJsonObject("value").get("@id").getAsString());
+
+    com.google.gson.JsonObject removeOp = patch.get(1).getAsJsonObject();
+    assertEquals("remove", removeOp.get("op").getAsString());
+    assertEquals("@graph/0/sempermissions:viewer/0", removeOp.get("path").getAsString());
+  }
+
+  @Test
+  public void unassignModelRoleRejectsUnknownRole() {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    try {
+      client.unassignModelRole(model, "bogus", "user:jsmith");
+      fail("Expected OEClientException for unknown role");
+    } catch (OEClientException e) {
+      assertTrue(e.getMessage().contains("bogus"));
+    }
+    assertEquals(0, client.makeRequestCallCount);
+  }
+
+  @Test
   public void createSymmetricRelationshipTypeIncludesSymmetricPropertyType() throws OEClientException {
     CapturingReadWriteClient client = newClient();
     Label label = new Label("en", "Related To");

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
@@ -533,6 +533,18 @@ public class OEClientReadWriteTest {
   }
 
   @Test
+  public void assignModelRoleAcceptsContributorRole() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    client.assignModelRole(model, "contributor", "user:jsmith");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    assertEquals("@graph/0/sempermissions:contributor/-",
+        patch.get(0).getAsJsonObject().get("path").getAsString());
+  }
+
+  @Test
   public void assignModelRoleRejectsUnknownRole() {
     CapturingReadWriteClient client = newClient();
     Model model = new Model("urn:model:1", new Label("en", "Model One"), null);

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
@@ -579,6 +579,62 @@ public class OEClientReadWriteTest {
   }
 
   @Test
+  public void assignModelRoleRejectsBlankPrincipalUri() {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    try {
+      client.assignModelRole(model, "manager", " ");
+      fail("Expected OEClientException for blank principalUri");
+    } catch (OEClientException e) {
+      assertTrue(e.getMessage().contains("principalUri"));
+    }
+    assertEquals(0, client.makeRequestCallCount);
+  }
+
+  @Test
+  public void unassignModelRoleRejectsNullPrincipalUri() {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    try {
+      client.unassignModelRole(model, "manager", null);
+      fail("Expected OEClientException for null principalUri");
+    } catch (OEClientException e) {
+      assertTrue(e.getMessage().contains("principalUri"));
+    }
+    assertEquals(0, client.makeRequestCallCount);
+  }
+
+  @Test
+  public void addModelTagRejectsBlankTag() {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    try {
+      client.addModelTag(model, " ");
+      fail("Expected OEClientException for blank tag");
+    } catch (OEClientException e) {
+      assertTrue(e.getMessage().contains("tag"));
+    }
+    assertEquals(0, client.makeRequestCallCount);
+  }
+
+  @Test
+  public void removeModelTagRejectsNullTag() {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    try {
+      client.removeModelTag(model, null);
+      fail("Expected OEClientException for null tag");
+    } catch (OEClientException e) {
+      assertTrue(e.getMessage().contains("tag"));
+    }
+    assertEquals(0, client.makeRequestCallCount);
+  }
+
+  @Test
   public void updateTaskLabelPatchTestOperationUsesValueKey() throws OEClientException {
     CapturingReadWriteClient client = newClient();
     Task task = new Task(new Label("en", "Old Task Name"), "task:1", "task:fp1:task1");
@@ -607,6 +663,41 @@ public class OEClientReadWriteTest {
     assertEquals("add", addOp.get("op").getAsString());
     assertEquals("@graph/0/rdfs:comment/-", addOp.get("path").getAsString());
     assertEquals("New description", addOp.getAsJsonObject("value").get("@value").getAsString());
+  }
+
+  @Test
+  public void updateModelDefaultNamespaceAddsWhenNoOldNamespace() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    client.updateModelDefaultNamespace(model, null, "http://example.com/model-one#");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    assertEquals(1, patch.size());
+    com.google.gson.JsonObject addOp = patch.get(0).getAsJsonObject();
+    assertEquals("add", addOp.get("op").getAsString());
+    assertEquals("@graph/0/swa:defaultNamespace/-", addOp.get("path").getAsString());
+    assertEquals("http://example.com/model-one#",
+        addOp.getAsJsonObject("value").get("@value").getAsString());
+  }
+
+  @Test
+  public void updateModelDefaultNamespaceTestsAndRemovesWhenOldNamespacePresent()
+      throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Model model = new Model("urn:model:1", new Label("en", "Model One"), null);
+
+    client.updateModelDefaultNamespace(model, "http://example.com/old#",
+        "http://example.com/new#");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    assertEquals(3, patch.size());
+    com.google.gson.JsonObject testOp = patch.get(0).getAsJsonObject();
+    assertEquals("test", testOp.get("op").getAsString());
+    assertEquals("http://example.com/old#",
+        testOp.getAsJsonObject("value").get("@value").getAsString());
+    com.google.gson.JsonObject removeOp = patch.get(1).getAsJsonObject();
+    assertEquals("remove", removeOp.get("op").getAsString());
   }
 
   @Test

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/OEClientReadWriteTest.java
@@ -520,6 +520,99 @@ public class OEClientReadWriteTest {
   }
 
   @Test
+  public void updateTaskLabelPatchTestOperationUsesValueKey() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Task task = new Task(new Label("en", "Old Task Name"), "task:1", "task:fp1:task1");
+
+    client.updateTaskLabel(task, "Old Task Name", "New Task Name");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    com.google.gson.JsonObject testOp = patch.get(0).getAsJsonObject();
+    assertEquals("test", testOp.get("op").getAsString());
+    assertEquals("Old Task Name", testOp.getAsJsonObject("value").get("@value").getAsString());
+    com.google.gson.JsonObject addOp = patch.get(2).getAsJsonObject();
+    assertEquals("New Task Name", addOp.getAsJsonObject("value").get("@value").getAsString());
+    assertTrue(client.lastUrl.endsWith("sys/task:fp1:task1"));
+  }
+
+  @Test
+  public void updateTaskCommentAddsWhenNoOldComment() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Task task = new Task(new Label("en", "Task One"), "task:1", "task:fp1:task1");
+
+    client.updateTaskComment(task, null, "New description");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    assertEquals(1, patch.size());
+    com.google.gson.JsonObject addOp = patch.get(0).getAsJsonObject();
+    assertEquals("add", addOp.get("op").getAsString());
+    assertEquals("@graph/0/rdfs:comment/-", addOp.get("path").getAsString());
+    assertEquals("New description", addOp.getAsJsonObject("value").get("@value").getAsString());
+  }
+
+  @Test
+  public void addAndRemoveTaskTagUseSharedTagPaths() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Task task = new Task(new Label("en", "Task One"), "task:1", "task:fp1:task1");
+
+    client.addTaskTag(task, "urgent");
+    com.google.gson.JsonArray addPatch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    assertEquals("@graph/0/sem:tag/-", addPatch.get(0).getAsJsonObject().get("path").getAsString());
+
+    client.removeTaskTag(task, "urgent");
+    com.google.gson.JsonArray removePatch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    assertEquals("test", removePatch.get(0).getAsJsonObject().get("op").getAsString());
+    assertEquals("@graph/0/sem:tag/0", removePatch.get(1).getAsJsonObject().get("path").getAsString());
+  }
+
+  @Test
+  public void assignTaskRolePayloadAddsPrincipalByReference() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Task task = new Task(new Label("en", "Task One"), "task:1", "task:fp1:task1");
+
+    client.assignTaskRole(task, "manager", "user:jsmith");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    com.google.gson.JsonObject addOp = patch.get(0).getAsJsonObject();
+    assertEquals("add", addOp.get("op").getAsString());
+    assertEquals("@graph/0/sempermissions:manager/-", addOp.get("path").getAsString());
+    assertEquals("user:jsmith", addOp.getAsJsonObject("value").get("@id").getAsString());
+    assertTrue(client.lastUrl.endsWith("sys/task:fp1:task1"));
+  }
+
+  @Test
+  public void assignTaskRoleRejectsUnknownRole() {
+    CapturingReadWriteClient client = newClient();
+    Task task = new Task(new Label("en", "Task One"), "task:1", "task:fp1:task1");
+
+    try {
+      client.assignTaskRole(task, "owner", "user:jsmith");
+      fail("Expected OEClientException for unknown role");
+    } catch (OEClientException e) {
+      assertTrue(e.getMessage().contains("owner"));
+    }
+    assertEquals(0, client.makeRequestCallCount);
+  }
+
+  @Test
+  public void unassignTaskRolePayloadTestsAndRemovesPrincipal() throws OEClientException {
+    CapturingReadWriteClient client = newClient();
+    Task task = new Task(new Label("en", "Task One"), "task:1", "task:fp1:task1");
+
+    client.unassignTaskRole(task, "viewer", "user:jsmith");
+
+    com.google.gson.JsonArray patch = JsonParser.parseString(client.lastPayload).getAsJsonArray();
+    com.google.gson.JsonObject testOp = patch.get(0).getAsJsonObject();
+    assertEquals("test", testOp.get("op").getAsString());
+    assertEquals("@graph/0/sempermissions:viewer/0", testOp.get("path").getAsString());
+    assertEquals("user:jsmith", testOp.getAsJsonObject("value").get("@id").getAsString());
+
+    com.google.gson.JsonObject removeOp = patch.get(1).getAsJsonObject();
+    assertEquals("remove", removeOp.get("op").getAsString());
+    assertEquals("@graph/0/sempermissions:viewer/0", removeOp.get("path").getAsString());
+  }
+
+  @Test
   public void createSymmetricRelationshipTypeIncludesSymmetricPropertyType() throws OEClientException {
     CapturingReadWriteClient client = newClient();
     Label label = new Label("en", "Related To");
@@ -560,12 +653,14 @@ public class OEClientReadWriteTest {
 
   private static class CapturingReadWriteClient extends OEClientReadWrite {
     private String lastPayload;
+    private String lastUrl;
     private int makeRequestCallCount;
     private String nextMakeRequestResponse;
     private Collection<Task> tasksResponse = Collections.emptyList();
 
     @Override
     protected String makeRequest(String url, String payload, RequestType requestType) {
+      this.lastUrl = url;
       this.lastPayload = payload;
       this.makeRequestCallCount++;
       return nextMakeRequestResponse;
@@ -573,6 +668,7 @@ public class OEClientReadWriteTest {
 
     @Override
     protected String makeRequest(String url, Map<String, String> queryParameters, String payload, RequestType requestType) {
+      this.lastUrl = url;
       this.lastPayload = payload;
       this.makeRequestCallCount++;
       return nextMakeRequestResponse;

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/beans/ModelTest.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/beans/ModelTest.java
@@ -1,12 +1,15 @@
 // Copyright (c) 2026 Progress Software Corporation and/or its subsidiaries or affiliates. All rights reserved.
 package com.smartlogic.ontologyeditor.beans;
 
+import org.apache.jena.atlas.json.JSON;
+import org.apache.jena.atlas.json.JsonObject;
 import org.junit.Test;
 
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class ModelTest {
@@ -30,4 +33,65 @@ public class ModelTest {
     assertNotNull(model.getLanguages());
     assertTrue(model.getLanguages().isEmpty());
   }
+
+  @Test
+  public void constructorWithDefaultNamespaceSetsIt() {
+    Model model = new Model("urn:model:1", new Label("en", "My Model"), "comment",
+        "http://example.com/my-model#");
+
+    assertEquals("http://example.com/my-model#", model.getDefaultNamespace());
+    assertNotNull(model.getLanguages());
+    assertTrue(model.getLanguages().isEmpty());
+  }
+
+  @Test
+  public void constructorWithoutDefaultNamespaceLeavesItNull() {
+    Model model = new Model("urn:model:1", new Label("en", "My Model"), null);
+
+    assertNull(model.getDefaultNamespace());
+  }
+
+  @Test
+  public void jsonConstructorParsesCommentAndDefaultNamespaceFromArrayValuedProperties() {
+    JsonObject jsonObject = JSON.parse("{"
+        + "\"meta:displayName\": {\"@value\": \"My Model\"},"
+        + "\"meta:graphUri\": {\"@id\": \"model:fp1\"},"
+        + "\"rdfs:comment\": [{\"@value\": \"A description\"}],"
+        + "\"swa:defaultNamespace\": [{\"@value\": \"http://example.com/fp1#\"}]"
+        + "}");
+
+    Model model = new Model(jsonObject);
+
+    assertEquals("A description", model.getComment());
+    assertEquals("http://example.com/fp1#", model.getDefaultNamespace());
+  }
+
+  @Test
+  public void jsonConstructorParsesCommentAndDefaultNamespaceFromSingleValuedProperties() {
+    JsonObject jsonObject = JSON.parse("{"
+        + "\"meta:displayName\": {\"@value\": \"My Model\"},"
+        + "\"meta:graphUri\": {\"@id\": \"model:fp1\"},"
+        + "\"rdfs:comment\": {\"@value\": \"A description\"},"
+        + "\"swa:defaultNamespace\": {\"@value\": \"http://example.com/fp1#\"}"
+        + "}");
+
+    Model model = new Model(jsonObject);
+
+    assertEquals("A description", model.getComment());
+    assertEquals("http://example.com/fp1#", model.getDefaultNamespace());
+  }
+
+  @Test
+  public void jsonConstructorLeavesCommentAndDefaultNamespaceNullWhenPropertiesAbsent() {
+    JsonObject jsonObject = JSON.parse("{"
+        + "\"meta:displayName\": {\"@value\": \"My Model\"},"
+        + "\"meta:graphUri\": {\"@id\": \"model:fp1\"}"
+        + "}");
+
+    Model model = new Model(jsonObject);
+
+    assertNull(model.getComment());
+    assertNull(model.getDefaultNamespace());
+  }
 }
+

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/examples/AddModel.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/examples/AddModel.java
@@ -21,8 +21,8 @@ public class AddModel extends ModelManipulation {
 		/* Be careful with this one. If you have built APITest model manually, this test will create another with the same name
 		but different URI. If you are pointing to a task in properties file, it'll create a weird model name.
 		 */
-		Model model = new Model(oeClient.getModelUri(), modelLabel, comment);
-		model.setDefaultNamespace("http://example.com/APITest#");
+		Model model = new Model(oeClient.getModelUri(), modelLabel, comment,
+				"http://example.com/APITest#");
 		oeClient.createModel(model);
 	}
 }

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/examples/AddMultipleModelsAndTasks.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/examples/AddMultipleModelsAndTasks.java
@@ -22,8 +22,7 @@ public class AddMultipleModelsAndTasks extends ModelManipulation {
             String comment = "Model created for testing the Java OE Client API";
 
             String modelUri = "model:MultipleModel" + i;
-            Model model = new Model(modelUri, modelLabel, comment);
-            model.setDefaultNamespace("http://example.com/APITest#");
+            Model model = new Model(modelUri, modelLabel, comment, "http://example.com/APITest#");
             oeClient.createModel(model);
 
             oeClient.setModelUri(modelUri);

--- a/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/examples/LinkModels.java
+++ b/Semaphore-OE-Client/src/test/java/com/smartlogic/ontologyeditor/examples/LinkModels.java
@@ -18,13 +18,15 @@ public class LinkModels extends ModelManipulation {
 		Label modelLabel1 = new Label("", "Linking model");
 		String comment1 = "Model created for testing the Java OE Client API";
 		oeClient.setModelUri("model:LinkingModel");
-		Model model1 = new Model(oeClient.getModelUri(), modelLabel1, comment1);
+		Model model1 = new Model(oeClient.getModelUri(), modelLabel1, comment1,
+				"http://example.com/LinkingModel#");
 		oeClient.createModel(model1);
 
 		Label modelLabel2 = new Label("", "Linked model");
 		String comment2 = "Model created for testing the Java OE Client API";
 		oeClient.setModelUri("model:LinkedModel");
-		Model model2 = new Model(oeClient.getModelUri(), modelLabel2, comment2);
+		Model model2 = new Model(oeClient.getModelUri(), modelLabel2, comment2,
+				"http://example.com/LinkedModel#");
 		oeClient.createModel(model2);
 
 		oeClient.setModelUri(model1.getUri());


### PR DESCRIPTION
## Summary
Adds write APIs to `OEClientReadWrite` for updating model/task settings
(display name, comment, default namespace, color, tags, permission roles)
and deleting models/tasks, plus a new `Model` constructor that accepts a
default namespace at construction time.

## Changes
- `OEClientReadWrite`: new methods to update display name, comment, default
  namespace, and color on a model (color/namespace are model-only), add/remove
  tags, and assign/unassign permission roles on models and tasks via
  JSON-Patch `test`/`remove`/`add` operations against `sys/{uri}`.
- Permission roles now include all four KMM roles: `manager`, `editor`,
  `contributor`, `viewer` (`viewer` is displayed as "Reviewer" in the KMM UI).
  `assignRole`/`unassignRole`/`addTag`/`removeTag` validate their required
  identifier arguments (`principalUri`, `tag`) upfront and reject null/blank
  values with `OEClientException`.
- `updateModelDefaultNamespace`/`updateComment`/`updateModelColor` only emit
  `test`/`remove` patch ops when an old value is actually present, since these
  fields may legitimately be unset; the exception message from `createModel()`
  now also references the new `Model(uri, label, comment, defaultNamespace)`
  constructor as an alternative to `setDefaultNamespace(...)`.
- `Model` bean: new constructor overload taking `defaultNamespace` directly
  (existing constructors kept for backward compatibility); `OEClientReadOnly`
  now reads and exposes the default namespace when fetching a model/task.
- `OEClientReadWriteTest`: added coverage for the new update/tag/role methods,
  including validation-rejection and default-namespace add-vs-test/remove
  behavior; new tests for the `Model` default-namespace constructor.
- Integration tests: added `OEClientModelSettingsIT` and `OEClientTaskSettingsIT`
  covering the update APIs end-to-end against a live server; common property-
  fetch logic moved into `AbstractModelScopedIT.getPropertyValues(...)` to
  remove duplication between the two IT classes.

## Testing
- Full unit test suite: 82/82 passing (`mvn -o clean test`).
- Integration tests compile via `mvn -o test-compile`
  (`OEClientModelSettingsIT`, `OEClientTaskSettingsIT`).

## Related
- AB#37469
- Used by Progress-Data-Platform/Semaphore-kmm-ai-assistant#23
